### PR TITLE
EB-141: Use vanilla JS instead of jquery where possible

### DIFF
--- a/hugo/layouts/glossary/list.html
+++ b/hugo/layouts/glossary/list.html
@@ -95,10 +95,6 @@
 
 </div>
 
-
-<link href="/Datatables/datatables.min.css" rel="stylesheet">
-<script src="/Datatables/datatables.min.js"></script>
-
 <script>
     document.addEventListener('DOMContentLoaded', function() {
         new DataTable('#glossaryTable', {

--- a/hugo/layouts/index.html
+++ b/hugo/layouts/index.html
@@ -105,14 +105,14 @@
     const speciesCards = Array.from(document.querySelectorAll('.scilife-species-card'));
 
     function sortAlphabetically(a, b) {
-        const titleA = $(a).find('#science-name').text();
-        const titleB = $(b).find('#science-name').text();
+        const titleA = a.querySelector('#science-name').textContent;
+        const titleB = b.querySelector('#science-name').textContent;
         return titleA.localeCompare(titleB);
     }
 
     function sortRevAlphabetically(a, b) {
-        const titleA = $(a).find('#science-name').text();
-        const titleB = $(b).find('#science-name').text();
+        const titleA = a.querySelector('#science-name').textContent;
+        const titleB = b.querySelector('#science-name').textContent;
         return titleB.localeCompare(titleA);
     }
 
@@ -124,8 +124,8 @@
     }
 
     function sortUpdated(a, b) {
-        const dateStrA = $(a).find('.hidden-date').text();
-        const dateStrB = $(b).find('.hidden-date').text();
+        const dateStrA = a.querySelector('.hidden-date').textContent;
+        const dateStrB = b.querySelector('.hidden-date').textContent;
 
         const dateA = stringToDate(dateStrA);
         const dateB = stringToDate(dateStrB);

--- a/hugo/layouts/index.html
+++ b/hugo/layouts/index.html
@@ -108,7 +108,7 @@
     function getElementText(root, selector) {
         const element = root.querySelector(selector);
         if (!element) {
-            console.debug(`Element not found for selector: ${selector}`);
+            console.warn(`Element not found for selector: ${selector} in root: ${root}`);
             return '';
         }
         return element.textContent;

--- a/hugo/layouts/index.html
+++ b/hugo/layouts/index.html
@@ -104,9 +104,19 @@
 <script>
     const speciesCards = Array.from(document.querySelectorAll('.scilife-species-card'));
 
+    // helper function to handle missing elements by returning empty string
+    function getElementText(root, selector) {
+        const element = root.querySelector(selector);
+        if (!element) {
+            console.debug(`Element not found for selector: ${selector}`);
+            return '';
+        }
+        return element.textContent;
+    }
+
     function sortAlphabetically(a, b) {
-        const titleA = a.querySelector('#science-name').textContent;
-        const titleB = b.querySelector('#science-name').textContent;
+        const titleA = getElementText(a, '#science-name');
+        const titleB = getElementText(b, '#science-name');
         return titleA.localeCompare(titleB);
     }
 
@@ -120,8 +130,8 @@
     }
 
     function sortUpdated(a, b) {
-        const dateStrA = a.querySelector('.hidden-date').textContent;
-        const dateStrB = b.querySelector('.hidden-date').textContent;
+        const dateStrA = getElementText(a, '.hidden-date');
+        const dateStrB = getElementText(b, '.hidden-date');
 
         const dateA = stringToDate(dateStrA);
         const dateB = stringToDate(dateStrB);
@@ -141,9 +151,9 @@
             cardsToAppend = speciesCards.slice();
         } else {
             cardsToAppend = speciesCards.filter(function (card) {
-                const title = card.querySelector('#science-name').textContent.toLowerCase();
-                const subtitle = card.querySelector('#common-name').textContent.toLowerCase();
-                const cardText = card.querySelector('.card-text').textContent.toLowerCase();
+                const title = getElementText(card, '#science-name').toLowerCase();
+                const subtitle = getElementText(card, '#common-name').toLowerCase();
+                const cardText = getElementText(card, '.card-text').toLowerCase();
                 return title.includes(searchText) || subtitle.includes(searchText) || cardText.includes(searchText);
             });
         }

--- a/hugo/layouts/index.html
+++ b/hugo/layouts/index.html
@@ -110,11 +110,7 @@
         return titleA.localeCompare(titleB);
     }
 
-    function sortRevAlphabetically(a, b) {
-        const titleA = a.querySelector('#science-name').textContent;
-        const titleB = b.querySelector('#science-name').textContent;
-        return titleB.localeCompare(titleA);
-    }
+    const sortRevAlphabetically = (a, b) => -sortAlphabetically(a, b);
 
     // All dates have DD/MM/YYYY format but
     // JS Dates object need standard define in stringToDate function

--- a/hugo/layouts/partials/distrib_map.html
+++ b/hugo/layouts/partials/distrib_map.html
@@ -35,20 +35,12 @@
 </div>
 
 
-<link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
-    integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin="" />
-
-<script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
-    integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
-
-
+<!-- Leaflet observation map script -->
 {{ $latitude := .Params.latitude | default 0 }}
 {{ $longitude := .Params.longitude | default 0 }}
 {{ $initialZoom := .Params.initialZoom | default 1 }}
 
-
 <script>
-
     const map = L.map('map', {
         minZoom: 1,
         maxZoom: 15,

--- a/hugo/layouts/partials/distrib_map.html
+++ b/hugo/layouts/partials/distrib_map.html
@@ -116,8 +116,10 @@
 
                 helpControl.addTo(map);
 
-                $('#helpButton').click(function() {
-                    $('.toast').toast('show');
+                document.getElementById('helpButton').addEventListener('click', function() {
+                    document.querySelectorAll('.toast').forEach(function(toast) {
+                        toast.classList.add('show');
+                    });
                 });
             }
         }

--- a/hugo/layouts/partials/download_table.html
+++ b/hugo/layouts/partials/download_table.html
@@ -114,12 +114,7 @@
         </a>
       </caption>
     </div>
-  </div>
-
-
-
-<link href="/Datatables/datatables.min.css" rel="stylesheet">
-<script src="/Datatables/datatables.min.js"></script>
+</div>
 
 <script>
     document.addEventListener('DOMContentLoaded', function() {

--- a/hugo/layouts/partials/head.html
+++ b/hugo/layouts/partials/head.html
@@ -58,13 +58,6 @@
         integrity="sha256-/JqT3SQfawRcv/BIHPThkBvs0OEvtFFmqPF/lYI/Cxo=" crossorigin="anonymous">
     </script>
 
-
-    {{ if $.Params.jbrowse }}
-        <script src="https://unpkg.com/react@18/umd/react.production.min.js" crossorigin></script>
-        <script src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js" crossorigin></script>
-        <script src="https://unpkg.com/@jbrowse/react-app/dist/react-app.umd.development.js" crossorigin></script>
-    {{ end }}
-
     {{ if eq .Type "contact" }}
         <script type="text/javascript">
             var onloadCallback = function () {

--- a/hugo/layouts/partials/head.html
+++ b/hugo/layouts/partials/head.html
@@ -28,7 +28,15 @@
     <link rel="preconnect" href="https://cdn.jsdelivr.net">
     {{ if or (eq .Title "Glossary") (eq .Title "Download") (eq .Title "Genome assembly") }}
         <link rel="preconnect" href="https://code.jquery.com">
-        <link rel="preconnect" href="https://cdn.datatables.net">
+    {{ end }}
+
+    {{ if eq .Params.layout "species_intro" }}
+        <link rel="preconnect" href="https://unpkg.com">
+    {{ end }}
+
+    {{ if eq .Title "Contact" }}
+        <link rel="preconnect" href="https://www.google.com">
+        <link rel="preconnect" href="https://www.gstatic.com" crossorigin>
     {{ end }}
 
     <!-- Google Font for Roboto-->
@@ -65,6 +73,19 @@
         <script src="/Datatables/datatables.min.js"></script>
     {{ end }}
 
+    <!-- Leaflet -->
+    {{ if eq .Params.layout "species_intro" }}
+        <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
+            integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin="" />
+
+        <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
+            integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
+    {{ end }}
+
+    <!-- Load the Google reCAPTCHA API asynchronously and defer its execution until the page has finished parsing -->
+    {{ if eq .Title "Contact" }}
+        <script src="https://www.google.com/recaptcha/api.js?onload=onloadCallback&render=explicit" async defer></script>
+    {{ end }}
 
     <!-- Matomo tracking info -->
     {{ if eq .Type "contact" }}

--- a/hugo/layouts/partials/head.html
+++ b/hugo/layouts/partials/head.html
@@ -25,8 +25,11 @@
     <!-- Establishing early connections to speed up downloads -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link rel="preconnect" href="https://code.jquery.com">
     <link rel="preconnect" href="https://cdn.jsdelivr.net">
+
+    {{ if or (eq .Title "Glossary") (eq .Title "Download") }}
+        <link rel="preconnect" href="https://code.jquery.com">
+    {{ end }}
 
     <!-- Google Font for Roboto-->
     <link href="https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,400;0,500;0,700;1,400;1,500;1,700&display=swap" rel="stylesheet">
@@ -53,10 +56,12 @@
         crossorigin="anonymous">
     </script>
 
-    <!-- JQuery -->
-    <script src="https://code.jquery.com/jquery-3.7.1.min.js"
-        integrity="sha256-/JqT3SQfawRcv/BIHPThkBvs0OEvtFFmqPF/lYI/Cxo=" crossorigin="anonymous">
-    </script>
+    <!-- JQuery sometimes needed with datatables library -->
+    {{ if or (eq .Title "Glossary") (eq .Title "Download") }}
+        <script src="https://code.jquery.com/jquery-3.7.1.min.js"
+            integrity="sha256-/JqT3SQfawRcv/BIHPThkBvs0OEvtFFmqPF/lYI/Cxo=" crossorigin="anonymous">
+        </script>
+    {{ end }}
 
     {{ if eq .Type "contact" }}
         <script type="text/javascript">

--- a/hugo/layouts/partials/head.html
+++ b/hugo/layouts/partials/head.html
@@ -26,9 +26,9 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link rel="preconnect" href="https://cdn.jsdelivr.net">
-
-    {{ if or (eq .Title "Glossary") (eq .Title "Download") }}
+    {{ if or (eq .Title "Glossary") (eq .Title "Download") (eq .Title "Genome assembly") }}
         <link rel="preconnect" href="https://code.jquery.com">
+        <link rel="preconnect" href="https://cdn.datatables.net">
     {{ end }}
 
     <!-- Google Font for Roboto-->
@@ -56,13 +56,17 @@
         crossorigin="anonymous">
     </script>
 
-    <!-- JQuery sometimes needed with datatables library -->
-    {{ if or (eq .Title "Glossary") (eq .Title "Download") }}
+    <!-- Datatables (sometimes needs Jquery as dependancy) -->
+    {{ if or (eq .Title "Glossary") (eq .Title "Download") (eq .Title "Genome assembly") }}
         <script src="https://code.jquery.com/jquery-3.7.1.min.js"
             integrity="sha256-/JqT3SQfawRcv/BIHPThkBvs0OEvtFFmqPF/lYI/Cxo=" crossorigin="anonymous">
         </script>
+        <link href="/Datatables/datatables.min.css" rel="stylesheet">
+        <script src="/Datatables/datatables.min.js"></script>
     {{ end }}
 
+
+    <!-- Matomo tracking info -->
     {{ if eq .Type "contact" }}
         <script type="text/javascript">
             var onloadCallback = function () {

--- a/hugo/layouts/shortcodes/contact_form.html
+++ b/hugo/layouts/shortcodes/contact_form.html
@@ -86,9 +86,6 @@
 
 </form>
 
-<script src="https://www.google.com/recaptcha/api.js?onload=onloadCallback&render=explicit" async defer></script>
-
-
 <script>
     const form = document.querySelector('.needs-validation');
     const formAlert = document.getElementById('formAlert');

--- a/hugo/layouts/shortcodes/contact_form.html
+++ b/hugo/layouts/shortcodes/contact_form.html
@@ -96,7 +96,7 @@
 
     form.addEventListener('submit', function (event) {
         const isFormValid = form.checkValidity();
-        const recaptchaValue = $("#g-recaptcha-response").val();
+        const recaptchaValue = grecaptcha.getResponse();
 
         if (!isFormValid || recaptchaValue === "") {
             event.preventDefault();

--- a/hugo/layouts/species/species_assembly.html
+++ b/hugo/layouts/species/species_assembly.html
@@ -153,9 +153,6 @@
 
 {{ define "scripts" }}
 
-<link href="/Datatables/datatables.min.css" rel="stylesheet">
-<script src="/Datatables/datatables.min.js"></script>
-
 <script>
     document.addEventListener('DOMContentLoaded', function() {
         new DataTable('#assemblyTable', {

--- a/hugo/layouts/species/species_download.html
+++ b/hugo/layouts/species/species_download.html
@@ -74,12 +74,12 @@
             shortTable.style.display = 'none';
         }
 
-    // Initialize DataTables if not already initialized
-    if (!$.fn.DataTable.isDataTable('#downloadTableLong')) {
-            $('#downloadTableLong').DataTable();
+        // Initialize DataTables if not already initialized
+        if (!document.querySelector('#downloadTableLong').classList.contains('dataTable')) {
+            new DataTable('#downloadTableLong');
         }
-        if (!$.fn.DataTable.isDataTable('#downloadTableShort')) {
-            $('#downloadTableShort').DataTable();
+        if (!document.querySelector('#downloadTableShort').classList.contains('dataTable')) {
+            new DataTable('#downloadTableShort');
         }
     });
 


### PR DESCRIPTION
Before this PR, jQuery was added as a dependency for all pages and used in some pages as part of some JS scripts throughout the website. I've now removed it to only be used when the Datatables library is loaded (jquery is a dependency) and replaced the other instances with vanilla JS. This therefore helps to improve the sites' load speed by not having to load jquery from a CDN.  

I've also taken the opportunity to move all downloads of scripts/style sheets to one place, ` head.html`, so it is easier to keep track of. Finally I've added [some preconnects](https://developer.chrome.com/docs/lighthouse/performance/uses-rel-preconnect) too to help with the site's loading speeds. 