### PR TITLE
EB-179: Configure production and development Docker image builds

### DIFF
--- a/.github/workflows/data-builder-container.yml
+++ b/.github/workflows/data-builder-container.yml
@@ -1,15 +1,16 @@
 name: Build and push the data builder image to GitHub Container Registry
 on:
   push:
-    tags:
-      - 'v*.*.*' # i.e. has to have a release tag to run 
+    branches:
+      - prod # aka prod/stable
+      - main # aka dev
       
-  # if run as workflow_dispatch, these tags can be used in build+push step
   workflow_dispatch:
     inputs:
       docker_tag:
-        description: 'Docker tag for the image'
+        description: 'Docker tag for the image, default is dev'
         required: false
+        default: 'dev'
 
 jobs:
   push-to-container-registry:
@@ -32,6 +33,17 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Set Docker tag
+        id: set-tag
+        run: |
+          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+            echo "tag=${{ github.event.inputs.docker_tag }}" >> $GITHUB_OUTPUT;
+          elif [ "${{ github.ref }}" == "refs/heads/prod" ]; then
+            echo "tag=prod" >> $GITHUB_OUTPUT;
+          elif [ "${{ github.ref }}" == "refs/heads/main" ]; then
+            echo "tag=dev" >> $GITHUB_OUTPUT;
+          fi
+
       - name: Create Docker metadata
         id: meta
         uses: docker/metadata-action@v5
@@ -47,9 +59,8 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v5
         with:
-
           push: ${{ github.event_name != 'pull_request' }}
           context: .
           file: ./docker/data.dockerfile
-          tags: ${{ github.event.inputs.docker_tag || steps.meta.outputs.tags }}
+          tags: ghcr.io/scilifelabdatacentre/swg-data-builder:${{ steps.set-tag.outputs.tag }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/data-builder-container.yml
+++ b/.github/workflows/data-builder-container.yml
@@ -2,9 +2,10 @@ name: Build and push the data builder image to GitHub Container Registry
 on:
   push:
     branches:
-      - prod # aka prod/stable
-      - main # aka dev
-      
+      - prod # Branch to be deployed in production, through builds tagged prod
+      - main # Branch to be deployed in development, through builds tagged dev
+  
+  # workflow_dispatch can be used on feature branch to test the site on dev instance
   workflow_dispatch:
     inputs:
       docker_tag:

--- a/.github/workflows/data-builder-container.yml
+++ b/.github/workflows/data-builder-container.yml
@@ -4,7 +4,9 @@ on:
     branches:
       - prod # Branch to be deployed in production, through builds tagged prod
       - main # Branch to be deployed in development, through builds tagged dev
-  
+    paths-ignore:
+      - 'README.md' # changes to only readme will not trigger a rebuild
+
   # workflow_dispatch can be used on feature branch to test the site on dev instance
   workflow_dispatch:
     inputs:

--- a/.github/workflows/data-builder-container.yml
+++ b/.github/workflows/data-builder-container.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   push-to-container-registry:
-    if: github.repository == 'ScilifelabDataCentre/swedgene'  
+    if: github.repository == 'ScilifelabDataCentre/genome-portal'  
     name: Build and push the data builder Docker image to GitHub Container Registry
 
     runs-on: ubuntu-latest

--- a/.github/workflows/hugo-container.yml
+++ b/.github/workflows/hugo-container.yml
@@ -2,8 +2,8 @@ name: Build and push Hugo site image to GitHub Container Registry
 on:
   push:
     branches:
-      - prod # aka prod/stable
-      - main # aka dev
+      - prod # Branch to be deployed in production, through builds tagged prod
+      - main # Branch to be deployed in development, through builds tagged dev
       
   # workflow_dispatch can be used on feature branch to test the site on dev instance
   workflow_dispatch:

--- a/.github/workflows/hugo-container.yml
+++ b/.github/workflows/hugo-container.yml
@@ -4,7 +4,9 @@ on:
     branches:
       - prod # Branch to be deployed in production, through builds tagged prod
       - main # Branch to be deployed in development, through builds tagged dev
-      
+    paths-ignore:
+      - 'README.md' # changes to only readme will not trigger rebuild
+  
   # workflow_dispatch can be used on feature branch to test the site on dev instance
   workflow_dispatch:
     inputs:

--- a/.github/workflows/hugo-container.yml
+++ b/.github/workflows/hugo-container.yml
@@ -1,15 +1,17 @@
 name: Build and push Hugo site image to GitHub Container Registry
 on:
   push:
-    tags:
-      - 'v*.*.*' # i.e. has to have a release tag to run 
+    branches:
+      - prod # aka prod/stable
+      - main # aka dev
       
-  # if run as workflow_dispatch, these tags can be used in build+push step
+  # workflow_dispatch can be used on feature branch to test the site on dev instance
   workflow_dispatch:
     inputs:
       docker_tag:
-        description: 'Docker tag for the image'
+        description: 'Docker tag for the image, default is dev'
         required: false
+        default: 'dev'
 
 jobs:
   push-to-container-registry:
@@ -31,6 +33,17 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Set Docker tag
+        id: set-tag
+        run: |
+          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+            echo "tag=${{ github.event.inputs.docker_tag }}" >> $GITHUB_OUTPUT;
+          elif [ "${{ github.ref }}" == "refs/heads/prod" ]; then
+            echo "tag=prod" >> $GITHUB_OUTPUT;
+          elif [ "${{ github.ref }}" == "refs/heads/main" ]; then
+            echo "tag=dev" >> $GITHUB_OUTPUT;
+          fi
 
       - name: Create Docker metadata
         id: meta
@@ -47,9 +60,8 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v5
         with:
-
           push: ${{ github.event_name != 'pull_request' }}
           context: .
           file: ./docker/hugo.dockerfile
-          tags: ${{ github.event.inputs.docker_tag || steps.meta.outputs.tags }}
+          tags: ghcr.io/scilifelabdatacentre/swg-hugo-site:${{ steps.set-tag.outputs.tag }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/hugo-container.yml
+++ b/.github/workflows/hugo-container.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   push-to-container-registry:
-    if: github.repository == 'ScilifelabDataCentre/swedgene'  
+    if: github.repository == 'ScilifelabDataCentre/genome-portal'  
     name: Build and push Hugo site Docker image to GitHub Container Registry
 
     runs-on: ubuntu-latest

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -3,14 +3,14 @@ on:
   push:
     branches:
       - main
-      - develop
+      - prod
     paths:
       - 'hugo/**'
   
   pull_request:
     branches:
       - main
-      - develop
+      - prod
     paths:
       - 'hugo/**'
 

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -2,15 +2,15 @@ name: Build hugo site and test site with Lighthouse CI
 on:
   push:
     branches:
-      - main
-      - prod
+      - prod # Branch to be deployed in production, through builds tagged prod
+      - main # Branch to be deployed in development, through builds tagged dev 
     paths:
       - 'hugo/**'
   
   pull_request:
     branches:
-      - main
-      - prod
+      - prod # Branch to be deployed in production, through builds tagged prod
+      - main # Branch to be deployed in development, through builds tagged dev 
     paths:
       - 'hugo/**'
 

--- a/.github/workflows/precommit.yml
+++ b/.github/workflows/precommit.yml
@@ -4,11 +4,11 @@ on:
   push:
     branches:
       - main
-      - develop
+      - prod
   pull_request:
     branches:
       - main
-      - develop
+      - prod
 
 jobs:
   pre_commit:

--- a/.github/workflows/precommit.yml
+++ b/.github/workflows/precommit.yml
@@ -3,12 +3,12 @@ name: Run pre-commit checks
 on:
   push:
     branches:
-      - main
-      - prod
+      - prod # Branch to be deployed in production, through builds tagged prod
+      - main # Branch to be deployed in development, through builds tagged dev 
   pull_request:
     branches:
-      - main
-      - prod
+      - prod # Branch to be deployed in production, through builds tagged prod
+      - main # Branch to be deployed in development, through builds tagged dev 
 
 jobs:
   pre_commit:

--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -2,12 +2,12 @@ name: Trivy - Security scan
 on:
   push:
     branches:
-      - main
-      - prod
+      - prod # Branch to be deployed in production, through builds tagged prod
+      - main # Branch to be deployed in development, through builds tagged dev 
   pull_request:
     branches:
-      - main
-      - prod
+      - prod # Branch to be deployed in production, through builds tagged prod
+      - main # Branch to be deployed in development, through builds tagged dev 
   schedule:
     - cron: '15 5 * * 3' # runs at 5:15 AM every Wednesday
     

--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -3,11 +3,11 @@ on:
   push:
     branches:
       - main
-      - develop
+      - prod
   pull_request:
     branches:
       - main
-      - develop
+      - prod
   schedule:
     - cron: '15 5 * * 3' # runs at 5:15 AM every Wednesday
     


### PR DESCRIPTION
Hey :) 

We have 5 workflows, 2 of which build images and the other 3 are more testing related. 

For the 3 testing related I have set it up so that both a PR or push to main or prod triggers them to run. 

**For the 2 that build images I have now set it up so that:** 
- On PR no images are built.
- On push to prod, both images are built with tag "prod".
- On push to main both images are built with tag "dev". 
- A workflow_dispatch (manual job) can be triggered to build either image on any branch (but not a fork). The default tag for the workflow dispatch will be "dev", but we have the choice to change that if we want when triggering the workflow. 

I think this matches up with our plan. I've been testing out these settings using a personal repository and there it seems to be working nicely at least. 


Related to this is of course the configuration of the branch settings, you can see those I have setup here: https://github.com/ScilifelabDataCentre/swedgene/settings/branches 

Cheers! 
