### PR TITLE
Content tweaks for first release

### DIFF
--- a/hugo/content/about/_index.md
+++ b/hugo/content/about/_index.md
@@ -28,7 +28,7 @@ The source code for the Genome Portal is publicly available on <a href="https:/
 
 ### Citation guidelines
 
-The recommended citations for the Genome Portal, source code, species pages, genome browser, and source data files can be found on the <a href="/citation" target="_blank">Cite us</a> page.
+Consult the <a href="/citation" target="_blank">Cite us</a> page for detailed citation guidelines.
 
 ### Terms of use
 

--- a/hugo/content/about/_index.md
+++ b/hugo/content/about/_index.md
@@ -13,8 +13,11 @@ The DSN-EB team comprises system developers, data stewards, and bioinformatician
 The Swedish Reference Genome Portal aims to:
 
 - Highlight and showcase genome research performed in Sweden.
+
 - Make it easier to access, visualise, and interpret genome data by lowering the barriers to entry.
+
 - Promote the sharing of genomic annotations that are rarely published.
+
 - Ensure all data displayed on the Genome Portal aligns with the <a href="https://www.go-fair.org/fair-principles/" target="_blank">FAIR principles</a> and is available in public repositories.
 
 ### Technical implementation and source code
@@ -25,7 +28,7 @@ The source code for the Genome Portal is publicly available on <a href="https:/
 
 ### Citation guidelines
 
-The recommended citations for the Genome Portal, source code, species pages, genome browser, and source data files can be found on the <a href="/citation" target="_blank">Cite us</a>.
+The recommended citations for the Genome Portal, source code, species pages, genome browser, and source data files can be found on the <a href="/citation" target="_blank">Cite us</a> page.
 
 ### Terms of use
 

--- a/hugo/content/about/sv/index.md
+++ b/hugo/content/about/sv/index.md
@@ -6,7 +6,7 @@ title: Information på svenska
 
 The Swedish Reference Genome Portal ("Den svenska portalen för referens-genom") är en kostnadsfri nationell datatjänst som syftar till att samla, tillgängliggöra och visualisera genom-assemblies och -annoteringar från icke-humana eukaryota arter producerade av eller i samarbete med forskare med an­knytning till institutioner i Sverige.
 
-Denna tjänst är utvecklad och underhålls av *The Data Science Node in Evolution and Biodiversity (DSN-EB)*-teamet som del av <a href="https://data.scilifelab.se" target="_blank">SciLifeLab Data Platform</a> som drivs av SciLifeLab Data Centre.
+Denna tjänst är utvecklad och underhålls av *The Data Science Node in Evolution and Biodiversity*(DSN-EB-teamet) som del av <a href="https://data.scilifelab.se" target="_blank">SciLifeLab Data Platform</a> som drivs av SciLifeLab Data Centre.
 
 DSN-EB-teamet består av systemutvecklare, data stewards och bionformatiker affilierade med <a href="https://www.scilifelab.se/data/" target="_blank">SciLifeLab Data Centre</a> och <a href="https://nbis.se" target="_blank">National Bioinformatics Infrastructure Sweden (NBIS)</a> vid Uppsala Universitet och Naturhistoriska Riksmuseet i Stockholm.
 
@@ -28,7 +28,7 @@ Genomportalen använder sig av öppen källkod under en *MIT open source*-licens
 
 ### Riktlinjer för att citera material på genomportalen
 
-Rekommendationen för att citera genomportalen, källkoden, de olika artsidorna, genom-browsern och datafilerna finns på <a href="/citation" target="_blank">Cite us</a>-sidan (på engelska).
+Besök <a href="/citation" target="_blank">Cite us</a>-sidan för detaljerade riktlinjer (på engelska).
 
 ### Användarvilkor
 

--- a/hugo/content/about/sv/index.md
+++ b/hugo/content/about/sv/index.md
@@ -4,23 +4,44 @@ title: Information på svenska
 
 ## Översikt
 
-The Swedish Reference Genome Portal ("Den svenska portalen för referens-genom") är en kostnadsfri tjänst som syftar till att samla, tillgängliggöra och visualisera genom-assemblies och -annoteringar från icke-humana eukaryota arter producerade av eller i samarbete med forskare med an­knytning till institutioner i Sverige. Denna tjänst tillhandahålls och underhålls av *The Data Science Node in Evolution and Biodiversity (DSN-EB)* som består av ett team av data stewards, dataingenjörer, systemutvecklare och bioinformatiker från [National Bioinformatics Infrastructure Sweden (NBIS)](https://nbis.se) och [SciLifeLab Data Centre](https://www.scilifelab.se/data/).
+The Swedish Reference Genome Portal ("Den svenska portalen för referens-genom") är en kostnadsfri nationell datatjänst som syftar till att samla, tillgängliggöra och visualisera genom-assemblies och -annoteringar från icke-humana eukaryota arter producerade av eller i samarbete med forskare med an­knytning till institutioner i Sverige.
 
-Arbetet med portalen är finansierat av [SciLifeLab](https://www.scilifelab.se) och [Knut and Alice Wallenbergs Stiftelse](https://kaw.wallenberg.org/) genom det nationella programmet för [Data-Driven Life Science (DDLS)](https://www.scilifelab.se/data-driven/), samt av [Stiftelsen för Strategisk Forskning (SSF)](https://strategiska.se/).
+Denna tjänst är utvecklad och underhålls av *The Data Science Node in Evolution and Biodiversity (DSN-EB)*-teamet som del av <a href="https://data.scilifelab.se" target="_blank">SciLifeLab Data Platform</a> som drivs av SciLifeLab Data Centre.
 
-**The Swedish Reference Genome Portal syftar till att:**
+DSN-EB-teamet består av systemutvecklare, data stewards och bionformatiker affilierade med <a href="https://www.scilifelab.se/data/" target="_blank">SciLifeLab Data Centre</a> och <a href="https://nbis.se" target="_blank">National Bioinformatics Infrastructure Sweden (NBIS)</a> vid Uppsala Universitet och Naturhistoriska Riksmuseet i Stockholm.
+
+Swedish Reference Genome Portal syftar till att:
 
 - framhäva och visa upp forskning om icke-humana eukaryota genom som utförts i Sverige.
-- främja offentlig delning av typer av genomik-data som annars sällan publiceras.
-- säkerställa att all data som visas upp i genomportalen är i linje med [FAIR-principerna](https://www.go-fair.org/fair-principles/) och tillgängliga i offentliga repositorier.
+
 - underlätta åtkomst, visualisering och tolkning av genomdata.
 
-## Användning
+- främja offentlig delning av typer av genomik-data som annars sällan publiceras.
 
-Alla är välkomna att använda denna webbplats, men för att kunna skicka in ett dataset till genomportalen finns det några få krav. Läs mer om kraven här: [requirements for adding a genome project](/contribute) (på engelska).
+- säkerställa att all data som visas upp i genomportalen är i linje med [FAIR-principerna](https://www.go-fair.org/fair-principles/) och tillgängliga i offentliga repositorier.
 
-## Tekniska detaljer
+### Technical implementation and source code
 
 Denna webbsida är byggd med hjälp av [Hugo](https://gohugo.io/) som är ett verktyg för att skapa statiska webbsidor. Genombrowsern [JBrowse2](https://jbrowse.org/jb2/)  används för att visualisera genomik-datan och är inbäddad i den statiska webbsidan. All data i genomportalen är öppet tillgänglig via offentliga repositorier. Portalen hämtar en kopia av all data för att visa upp i genombrowsern.
 
 Genomportalen använder sig av öppen källkod under en *MIT open source*-licens. Källkoden  finns att tillgå på [GitHub](https://github.com/ScilifelabDataCentre/genome-portal/). Portalen är driftsatt på ett [Kubernetes](https://kubernetes.io/)-kluster som finns vid  [Kungliga Tekniska Högskolan (KTH)](https://www.kth.se/) i Stockholm.
+
+### Riktlinjer för att citera material på genomportalen
+
+Rekommendationen för att citera genomportalen, källkoden, de olika artsidorna, genom-browsern och datafilerna finns på <a href="/citation" target="_blank">Cite us</a>-sidan (på engelska).
+
+### Användarvilkor
+
+Information om vad du kan förvänta dig av den här tjänsten, samt ansvarsfriskrivningar och begränsningar för denna webbplats och dess innehåll, finns på <a href="/terms" target="_blank">Terms of use</a>-sidan (på engelska).
+
+### Sekretess och integritetspolicy
+
+Information om vad, hur och varför personuppgifter och tekniska data hanteras och skyddas vid användning av denna webbplats finns på sidan <a href="/privacy" target="_blank">Privacy policy</a>-sidan (på engelska).
+
+### Finansiering
+
+Denna tjänst är finansierat av [SciLifeLab](https://www.scilifelab.se) och [Knut and Alice Wallenbergs Stiftelse](https://kaw.wallenberg.org/) genom det nationella programmet för [Data-Driven Life Science (DDLS)](https://www.scilifelab.se/data-driven/), samt av [Stiftelsen för Strategisk Forskning (SSF)](https://strategiska.se/).
+
+### Be om hjälp
+
+För frågor, kommentarer eller problem relaterade till genomportalen, vänligen kontakta oss per e-post på [dsn-eb@scilifelab.se](mailto:dsn-eb@scilifelab.se eller använd vårt <a href="/contact" target="_blank">kontaktformulär</a> (på engelska).

--- a/hugo/content/contribute/_index.md
+++ b/hugo/content/contribute/_index.md
@@ -26,8 +26,8 @@ For a species dataset to be included in the Genome Portal, it needs to fulfil th
 4. The **data is available in public repositories**. Example repositories include the European Nucleotide Archive - ENA, National Center of Biotechnology Information - NCBI, SciLifeLab Data Repository, Zenodo, among others.
 
 {{< info_block >}}
-We can also accept data under embargo expected to become available after the manuscript under review is approved for publication. The data should be deposited in a public repository and have a reserved DOI and/or accession number. This allows you to indicate in the Data Availability Statement of your manuscript that your data can be visualised on the Genome Portal.
-
+We can also accept data under embargo that is expected to become available after the manuscript is accepted for publication. The data should be deposited in a public repository and have a reserved DOI and/or accession number. This allows you to indicate in the Data Availability Statement of your manuscript that your data can be visualised on the Swedish Reference Genome Portal (see Section 1.3 on the <a href="/citation/#13-in-text-citation-in-the-data-availability-statement-of-a-manuscript")>Cite us</a> page for an example). The corresponding pages on the Genome Portal will be made public when the manuscript is accepted and the data has been made public.
+<br><br>
 Planning is key! Reach out to us via email at <dsn-eb@scilifelab.se> or through the <a href="/contact" target="_blank">Contact</a> form as soon as you wish to start this process.
 {{< /info_block >}}
 

--- a/hugo/content/terms/_index.md
+++ b/hugo/content/terms/_index.md
@@ -26,7 +26,7 @@ Genomic data attributed to individual species displayed on the Genome Portal com
 
 ### Using the content
 
-When you use the Swedish Reference Genome Portal website, its source code, the embedded genome browser, or the genomic data files in your work (e.g., publication, web page, presentation), we appreciate that you credit the respective contributor(s) by following the <a href="/citation" target="_blank">citation guidelines</a>.
+When you use the Swedish Reference Genome Portal website, its source code, the embedded genome browser, or the genomic data files in your work (e.g., publication, web page, presentation), we appreciate that you credit the respective contributor(s) by following the guidelines on the <a href="/citation" target="_blank">Cite us</a> page.
 
 ### Changes to the terms of use
 

--- a/hugo/layouts/partials/footer.html
+++ b/hugo/layouts/partials/footer.html
@@ -16,6 +16,7 @@
                     <li><a href="/glossary">Glossary</a></li>
                     <li><a href="/user-guide">User guide</a></li>
                     <li><a href="/privacy">Privacy policy</a></li>
+                    <li><a href="/terms">Terms of use</a></li>
                 </ul>
             </div>
 


### PR DESCRIPTION
This PR contains a few minor commits related to the commits in #64, a PR that was already merged in order to simplify the current branch flow.   

First of all, thanks for your great work on the pages @apfuentes. Well done! 

I took the liberty to commit the minor typos that I spotted in the branch. I hope that the commit descriptions should be self-explanatory. For 418a57b4b2f6a743158e7bc826f5b3e43c5e37ba, I assume that the Terms page should go in the footer, but please feel free to revert that commit if that was a premature decision from my side. 

I have not reviewed the FAQ and User Guide parts, since that will come in its own PR. But the little I saw so far looks good!

Here are some other comments / discussion points:
- Recommendations page
   the new title affects the breadcrumbs on the page. Was this your intention, Angela? I think it is fine this way too, but bear in mind that it now only says "Recommendations" which is more a broad and ambigous title than the previous "Reccomendations for file formats"
- Terms page
   I found one dead link that points to the FAQ. It will of course be fixed by the upcoming User Guide & FAQ PR. But I am just mentioning it here if for some reason the FAQ pages are not included in the first release.
- Links opening new tabs VS links opening in same tab:
   After this was raised by @RMCrean in the other PR (https://github.com/ScilifelabDataCentre/genome-portal/pull/64#pullrequestreview-2415094212), I realized that I have been inconsistent about this; both over time and across our different pages. My suggestion is this: external links open in new tab, internal links open in same tab (since the navbar is always accessible). But I think we can leave it like this for now and work on harmonizing this in a future release. Shall we make a Jira task for this?
- Update the footer with new version of text
   The About page now has the approved version of the text, but we should not forget to update the footer too. (To me it looks like it is the old version, so I leave this to @apfuentes to look at, since you have access to the approved text).