### PR TITLE
EB-140: Investigate if alias files can be used to recode more meaningful scaffold names

### DIFF
--- a/tests/config/recode_names/config.json
+++ b/tests/config/recode_names/config.json
@@ -1,0 +1,85 @@
+{
+  "assemblies": [
+    {
+      "name": "Linum_tenue_thrum_v1",
+      "refNameAliases": {
+        "adapter": {
+          "type": "NcbiSequenceReportAliasAdapter",
+          "location": {
+            "uri": "sequence_report.tsv"
+          }
+        }
+      },
+      "displayName": "L. tenue genome assembly GCA_946122785.1"
+    }
+  ],
+    "defaultSession": {
+      "id": "lten_default_session",
+      "name": "Linum tenue",
+      "widgets": {
+        "hierarchicalTrackSelector": {
+          "id": "hierarchicalTrackSelector",
+          "type": "HierarchicalTrackSelectorWidget",
+          "view": "lten_default_session_view",
+          "faceted": {
+            "showSparse": false,
+            "showFilters": true,
+            "showOptions": false,
+            "panelWidth": 400
+          }
+        }
+      },
+      "activeWidgets": {
+        "hierarchicalTrackSelector": "hierarchicalTrackSelector"
+      },
+      "views": [
+        {
+          "id": "lten_default_session_view",
+          "minimized": false,
+          "type": "LinearGenomeView",
+          "trackLabels": "offset",
+          "offsetPx": 0,
+          "bpPerPx": 100,
+          "displayedRegions": [
+            {
+              "refName": "LG1",
+              "start": 0,
+              "end": 72476498,
+              "reversed": false,
+              "assemblyName": "Linum_tenue_thrum_v1"
+            }
+          ],
+          "tracks": [
+            {
+              "id": "lten_default_protein_coding_genes",
+              "type": "FeatureTrack",
+              "configuration": "ltenue_v1_genes.gff",
+              "minimized": false,
+              "displays": [
+                {
+                  "id": "lten_default_protein_coding_genes_display",
+                  "type": "LinearBasicDisplay",
+                  "heightPreConfig": 180,
+                  "configuration": "ltenue_v1_genes.gff-LinearBasicDisplay"
+                }
+              ]
+            },
+            {
+              "id": "lten_default_repeats",
+              "type": "FeatureTrack",
+              "configuration": "L_tenue_v1_rep.bed",
+              "minimized": false,
+              "displays": [
+                {
+                  "id": "lten_default_repeats_display",
+                  "type": "LinearBasicDisplay",
+                  "heightPreConfig": 200,
+                  "configuration": "L_tenue_v1_rep.bed-LinearBasicDisplay"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+}

--- a/tests/config/recode_names/config.yml
+++ b/tests/config/recode_names/config.yml
@@ -1,0 +1,16 @@
+organism: "Linum tenue"
+assembly:
+  name: Linum_tenue_thrum_v1
+  displayName: "L. tenue genome assembly GCA_946122785.1"
+  accession: GCA_946122785.1
+  # The following url points to the original ENA upload of the assembly. It will require an alias file to be able to load the protein coding genes track
+  url: "https://ftp.ncbi.nlm.nih.gov/genomes/all/GCA/946/122/785/GCA_946122785.1_Linum_tenue_thrum_v1/GCA_946122785.1_Linum_tenue_thrum_v1_genomic.fna.gz"
+  # Temp storage for alias file.
+  aliases: "sequence_report.tsv"
+tracks:
+  - name: "Protein-coding genes"
+    url: "https://figshare.scilifelab.se/ndownloader/files/45076090"
+    fileName: "ltenue_v1_genes.gff.zip"
+  - name: "Repeats"
+    url: "https://figshare.scilifelab.se/ndownloader/files/48879751"
+    fileName: "L_tenue_v1_rep.bed.gz"

--- a/tests/fixtures/recode_names/sequence_report.tsv
+++ b/tests/fixtures/recode_names/sequence_report.tsv
@@ -1,0 +1,24 @@
+Assembly Accession	Assembly Unplaced Count	Assembly-unit accession	Chromosome name	GC Count	GC Percent	GenBank seq accession	Molecule type	Ordering	RefSeq seq accession	Role	Seq length	UCSC style name	Unlocalized Count
+GCA_946122785.1		Primary Assembly				CAMGYJ010000002.1	Chromosome		ABCDE	assembled-molecule	123556469	LG1
+GCA_946122785.1		Primary Assembly				CAMGYJ010000004.1	Chromosome		ABCDE	assembled-molecule		LG2
+GCA_946122785.1		Primary Assembly				CAMGYJ010000005.1	Chromosome		ABCDE	assembled-molecule		LG3
+GCA_946122785.1		Primary Assembly				CAMGYJ010000006.1	Chromosome		ABCDE	assembled-molecule		LG4
+GCA_946122785.1		Primary Assembly				CAMGYJ010000007.1	Chromosome		ABCDE	assembled-molecule		LG5
+GCA_946122785.1		Primary Assembly				CAMGYJ010000008.1	Chromosome		ABCDE	assembled-molecule		LG6
+GCA_946122785.1		Primary Assembly				CAMGYJ010000009.1	Chromosome		ABCDE	assembled-molecule		LG7
+GCA_946122785.1		Primary Assembly				CAMGYJ010000010.1	Chromosome		ABCDE	assembled-molecule		LG8
+GCA_946122785.1		Primary Assembly				CAMGYJ010000011.1	Chromosome		ABCDE	assembled-molecule		LG9
+GCA_946122785.1		Primary Assembly				CAMGYJ010000003.1	Chromosome		ABCDE	assembled-molecule		LG10
+GCA_946122785.1		Primary Assembly				CAMGYJ010000001.1	Chromosome		ABCDE	assembled-molecule		CHL
+GCA_946122785.1		Primary Assembly				CAMGYJ010000012.1	Chromosome		ABCDE	assembled-molecule		MIT1
+GCA_946122785.1		Primary Assembly				CAMGYJ010000013.1	Chromosome		ABCDE	assembled-molecule		MIT10
+GCA_946122785.1		Primary Assembly				CAMGYJ010000014.1	Chromosome		ABCDE	assembled-molecule		MIT11
+GCA_946122785.1		Primary Assembly				CAMGYJ010000015.1	Chromosome		ABCDE	assembled-molecule		MIT12
+GCA_946122785.1		Primary Assembly				CAMGYJ010000016.1	Chromosome		ABCDE	assembled-molecule		MIT2
+GCA_946122785.1		Primary Assembly				CAMGYJ010000017.1	Chromosome		ABCDE	assembled-molecule		MIT3
+GCA_946122785.1		Primary Assembly				CAMGYJ010000018.1	Chromosome		ABCDE	assembled-molecule		MIT4
+GCA_946122785.1		Primary Assembly				CAMGYJ010000019.1	Chromosome		ABCDE	assembled-molecule		MIT5
+GCA_946122785.1		Primary Assembly				CAMGYJ010000020.1	Chromosome		ABCDE	assembled-molecule		MIT6
+GCA_946122785.1		Primary Assembly				CAMGYJ010000021.1	Chromosome		ABCDE	assembled-molecule		MIT7
+GCA_946122785.1		Primary Assembly				CAMGYJ010000022.1	Chromosome		ABCDE	assembled-molecule		MIT8
+GCA_946122785.1		Primary Assembly				CAMGYJ010000023.1	Chromosome		ABCDE	assembled-molecule		MIT9


### PR DESCRIPTION
Recently, we have discussed that the scaffold names displayed in the dropdown in the JBrowse session are unnecessarily complex, as they consist of the just the sequence accession numbers. It would be desirable to change this into something more self-explanatory, or, at least, to scaffold names used internally by the research groups. For instance, `chr1`is often used as a short-hand for chromosome 1 for assemblies that are considered to have chromosome-level completeness.

This PR is to investigate if alias files can be used to recode more meaningful scaffold names using a [feature update in JBrowse v2.14.0](https://github.com/GMOD/jbrowse-components/pull/4516). The new feature introduces a `NcbiSequenceReportAliasAdapter` designed to allow NCBI `sequence_report.tsv` to be used as a refNameAlias and from there recode the displayed names of the scaffold in the JBrowse session.

The following experiment is focused on testing the feature in a reproducible manner to evaluate if it is something that we are interested in pursuing. This test implementation is not fully compatible with the current logic of the makefile. Instead it uses `jq` to do an *a posteri*  value adjustment to the final `config.json` to specify that `NcbiSequenceReportAliasAdapter` should be used instead of `RefNameAliasAdapter`. Specifying this in the initial `config.json` did not work, as it was overwritten when make runs the JBrowse CLI. The `sequence_report.tsv` used in this example uses a modified version of the file used in the [JBrowse PR](https://github.com/GMOD/jbrowse-components/blob/58541df89fc94cd4c7a04f28cd3f60b2dc99f56a/test_data/cfam2/sequence_report.tsv) populated with the data from the *L. tenue* assembly. `ABCDE` is a placeholder to check that the column was not used for the aliasing.

Commands:
```
SWG_TAG=local ./scripts/dockermake --test SPECIES=recode_names
jq '.assemblies[].refNameAliases.adapter.type = "NcbiSequenceReportAliasAdapter"' tests/data/recode_names/config.json > tests/data/recode_names/tmp.$$.json && mv tests/data/recode_names/tmp.$$.json tests/data/recode_names/config.json
cp tests/fixtures/recode_names/sequence_report.tsv tests/data/recode_names
docker stop jb2-recode_names; SWG_TAG=local ./scripts/browse tests/data/recode_names
```

Result: 
![Screenshot 2024-11-28 at 15 36 25](https://github.com/user-attachments/assets/4c6c8ba6-97db-4586-b43e-896b4feebcae)

The short-form *L. tenue* scaffold names now display as desired! However, there are some things to consider from this implementation:
- For this example, the aliasing works for the Figshare hosted files (i.e. the features are rendered as intended, see figure above). This is since both the GFF and the BED refer to the the short names of the scaffolds. Honestly, I think I was lucky in this case. My current understanding is that `NcbiSequenceReportAliasAdapter` only support two scaffold name synonyms to be aliased, which is reasonable given the scope of the [original PR](https://github.com/GMOD/jbrowse-components/pull/4516). In this case, there were only two synonyms: the ENA-formatted fasta header and the "Figshare"-formatted fasta header. But we have previously assumed that we might need three synonyms at times if we need to display ENA assembly, NCBI GFF, and research group track using different header formatting together.
- The ordering or the recoded scaffold names is still based on the original scaffold names. It would have been great to e.g. place LG10 after LG9, and the chloroplast (CHL) between the primary and mitochondrial scaffolds. Changing the row order in `sequence_report.tsv` to reflect this is ignored in the final session, indicating that the original names take precedence for sorting.
- In contrast to the former bullet, the defaultSession calls do need to be made to the recoded name and not to the original scaffold name. For instance: '.defaultSession.views[0].displayedRegions[0].refName' was changed to `LG1` from `ENA|CAMGYJ010000002|CAMGYJ010000002.1` to achieve the new working defaultSession.

In all, my impression at the time of writing is that I'm satisfied that this gives the desired results. The downside is that it might limit the aliasing to two synonyms and that we would need to implement a non-jq way to pass  `'.assemblies[].refNameAliases.adapter.type = "NcbiSequenceReportAliasAdapter"` to `config.json`.

I would also be happy to post these questions the JBrowse developers to see what they think. Perhaps a new adapter type would need to be developed to support more synonyms and custom ordering, who knows.

What do you think @apfuentes? Is the result like you envisioned? 
What are your thoughts, @kwentine? 
