### PR TITLE
Temporary fix for handling inaccessible data track url 

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -28,7 +28,6 @@ authors:
     orcid: "https://orcid.org/0000-0001-5875-8429"
 repository-code: "https://github.com/ScilifelabDataCentre/genome-portal"
 url: "https://genomes.scilifelab.se"
-abstract: "The Swedish Reference Genome Portal is a service facilitating access and discovery of genome data of non-model eukaryotic species studied in Sweden."
 license: MIT
 identifiers:
   - description: "This is the collection of archived snapshots of all versions of the Swedish Reference Genome Portal"

--- a/config/linum_trigynum/config.yml
+++ b/config/linum_trigynum/config.yml
@@ -37,7 +37,7 @@ tracks:
     fileName: "Ltri_pop07_TD.bed.gz"
     addTrack: false
   - name: "Ltri_pop08_TD.bed"
-    url: "https://figshare.scilifelab.se/ndownloader/files/50074047"
+    url: "https://figshare.scilifelab.se/ndownloader/files/49005208"
     fileName: "Ltri_pop08_TD.bed.gz"
     addTrack: false
   - name: "Ltri_pop10_TD.bed"

--- a/hugo/assets/linum_trigynum/data_tracks.json
+++ b/hugo/assets/linum_trigynum/data_tracks.json
@@ -113,14 +113,14 @@
   },
   {
     "dataTrackName": "Tajima's D, population 08",
-    "description": "Whole genome Tajima's D estimates for individuals of population 08 of L. trigynum per 100 kb windows.",
+    "description": "Whole genome Tajima's D estimates for individuals of population 08 of L. trigynum per 100 kb windows. (NOTE! File linked here has the correct data, but the file name is Ltri_pop08_Pi.bed.gz.)",
     "links": [
-      {"Download": "https://figshare.scilifelab.se/ndownloader/files/50074047"},
-      {"Website": "https://doi.org/10.17044/scilifelab.26937202.v2"},
+      {"Download": "https://figshare.scilifelab.se/ndownloader/files/49005208"},
+      {"Website": "https://doi.org/10.17044/scilifelab.26937202.v1"},
       {"Article": "https://doi.org/10.1016/j.cub.2022.08.042"}
     ],
-    "accessionOrDOI": "10.17044/scilifelab.26937202.v2",
-    "fileName": "Ltri_pop08_TD.bed.gz",
+    "accessionOrDOI": "10.17044/scilifelab.26937202.v1",
+    "fileName": "Ltri_pop08_Pi.bed.gz",
     "principalInvestigator": "Tanja Slotte",
     "principalInvestigatorAffiliation": "Stockholm University",
     "firstDateOnPortal": "31 October 2024"

--- a/playwright/tests/test_species_download_page.py
+++ b/playwright/tests/test_species_download_page.py
@@ -112,15 +112,13 @@ def validate_download_link(page: Page, link_locator: Locator, link_href: str) ->
     Checks the link is a direct download link, but does not wait for the download to complete.
     That could take way too long.
     """
-    KNOWN_FAILING_LINKS = "https://figshare.scilifelab.se/ndownloader/files/50074047"
 
     download_works = True
     try:
         with page.expect_download() as _:
             link_locator.click()
     except PlaywrightTimeoutError:
-        if link_href not in KNOWN_FAILING_LINKS:
-            download_works = False
+        download_works = False
 
     assert download_works, (
         f"A Download button link on the table on page: {page.url} does not appear to be a link.\n"


### PR DESCRIPTION
For the next release, it would be good to have a fix in place for the in inaccessible _L. trigynum_ link: b9caa0a. If the broken link gets fixed in the foreseeable future, supporting it it would mainly be a matter of reverting the edits in b9caa0a. But if the solution is to ask the submitter to upload the file anew, there will likely be a new url that needs to be added.

The other two commits are side things that I though would be of interest to have for the next release.

The first commit regards modifying the playwright test back to a previous state where it catches and warns for the broken link. I thought this was a fun exercise in applying the playwright tests in the troubleshooting work-flow. Command:

```
pytest playwright/tests/test_species_download_page.py::test_table_links  --base-url http://localhost:8080 
```

The third commit is a mini-experiment to improve the GitHub-Zenodo integration. Last time, the release notes were not added to the Zenodo record automatically as I thought they would (I edited that manually). I think the Abstract key is the culprit, so I removed it to see if it works better next time we make a release.

Anyway, I hope this should be straight-forward to review and that it can be merged and included for the next release.