### PR TITLE
EB-134: Add a Content Security Policy to the website

### DIFF
--- a/config/clupea_harengus/config.json
+++ b/config/clupea_harengus/config.json
@@ -1,1 +1,5 @@
-{}
+{
+  "configuration": {
+    "disableAnalytics": true
+  }
+}

--- a/config/linum_tenue/config.json
+++ b/config/linum_tenue/config.json
@@ -713,5 +713,8 @@
           }
         ]
       }
-    ]
+    ],
+    "configuration": {
+      "disableAnalytics": true
+    }
 }

--- a/config/linum_trigynum/config.json
+++ b/config/linum_trigynum/config.json
@@ -707,5 +707,8 @@
         }
       ]
     }
-  ]
+  ],
+  "configuration": {
+    "disableAnalytics": true
+  }
 }

--- a/config/littorina_saxatilis/config.json
+++ b/config/littorina_saxatilis/config.json
@@ -53,5 +53,8 @@
           "trackLabels": "offset"
         }
       ]
+    },
+    "configuration": {
+      "disableAnalytics": true
     }
 }

--- a/config/meganyctiphanes_norvegica/config.json
+++ b/config/meganyctiphanes_norvegica/config.json
@@ -53,6 +53,9 @@
           ]
         }
       ]
+    },
+    "configuration": {
+      "disableAnalytics": true
     }
-  }
+}
   

--- a/config/parnassius_mnemosyne/config.json
+++ b/config/parnassius_mnemosyne/config.json
@@ -128,6 +128,9 @@
           ]
         }
       ]
+    },
+    "configuration": {
+      "disableAnalytics": true
     }
-  }
+}
   

--- a/config/skeletonema_marinoi/config.json
+++ b/config/skeletonema_marinoi/config.json
@@ -53,6 +53,9 @@
           ]
         }
       ]
+    },
+    "configuration": {
+      "disableAnalytics": true
     }
-  }
+}
   

--- a/docker/nginx-custom.conf
+++ b/docker/nginx-custom.conf
@@ -20,7 +20,15 @@ server {
     add_header X-Frame-Options "SAMEORIGIN"; # don't allow iframing
     add_header X-Content-Type-Options "nosniff"; # prevent MIME type sniffing
     add_header X-XSS-Protection "1; mode=block"; # Cross-site scripting (XSS) filter
-
+    add_header Content-Security-Policy "
+        default-src 'self'; 
+        script-src 'self' https://cdn.jsdelivr.net http://matomo.dc.scilifelab.se https://www.google.com https://www.gstatic.com/ https://cdn.datatables.net https://code.jquery.com https://unpkg.com;  
+        style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdn.jsdelivr.net https://cdn.datatables.net https://unpkg.com; 
+        font-src 'self' https://fonts.gstatic.com https://cdn.jsdelivr.net; 
+        img-src 'self' data: https://tile.gbif.org https://api.gbif.org;
+        connect-src 'self' http://matomo.dc.scilifelab.se/ https://raw.githubusercontent.com https://analytics.jbrowse.org; 
+        frame-src 'self' https://www.google.com https://matomo.dc.scilifelab.se;
+    ";
     # cache media and font files for 30 days 
     location ~* \.(webp|svg|jpg|jpeg|png|gif|woff|woff2|ttf|eot|otf)$ {
         add_header Cache-Control "public, max-age=2592000";

--- a/docker/nginx-custom.conf
+++ b/docker/nginx-custom.conf
@@ -20,15 +20,7 @@ server {
     add_header X-Frame-Options "SAMEORIGIN"; # don't allow iframing
     add_header X-Content-Type-Options "nosniff"; # prevent MIME type sniffing
     add_header X-XSS-Protection "1; mode=block"; # Cross-site scripting (XSS) filter
-    add_header Content-Security-Policy "
-        default-src 'self'; 
-        script-src 'self' https://cdn.jsdelivr.net http://matomo.dc.scilifelab.se https://www.google.com https://www.gstatic.com/ https://cdn.datatables.net https://code.jquery.com https://unpkg.com;  
-        style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdn.jsdelivr.net https://cdn.datatables.net https://unpkg.com; 
-        font-src 'self' https://fonts.gstatic.com https://cdn.jsdelivr.net; 
-        img-src 'self' data: https://tile.gbif.org https://api.gbif.org;
-        connect-src 'self' http://matomo.dc.scilifelab.se/ https://raw.githubusercontent.com https://analytics.jbrowse.org; 
-        frame-src 'self' https://www.google.com https://matomo.dc.scilifelab.se;
-    ";
+
     # cache media and font files for 30 days 
     location ~* \.(webp|svg|jpg|jpeg|png|gif|woff|woff2|ttf|eot|otf)$ {
         add_header Cache-Control "public, max-age=2592000";

--- a/hugo/assets/js/check_for_config.js
+++ b/hugo/assets/js/check_for_config.js
@@ -1,0 +1,29 @@
+
+/* Check if a config file exists before loading JBrowse2
+Otherwise, display an alert to the user that no config file exists
+*/
+document.addEventListener('DOMContentLoaded', async function () {
+    const urlParams = new URLSearchParams(window.location.search);
+    const configFile = urlParams.get('config');
+    const noConfigBlock = document.getElementById('no-config');
+    const jbrowseBlock = document.getElementById('root');
+
+    if (!configFile) {
+        noConfigBlock.style.display = 'block';
+        jbrowseBlock.style.display = 'none';
+        return;
+    }
+
+    try {
+        const response = await fetch(configFile);
+        if (response.ok) {
+            return;
+        } else {
+            noConfigBlock.style.display = 'block';
+            jbrowseBlock.style.display = 'none';
+        }
+    } catch (error) {
+        noConfigBlock.style.display = 'block';
+        jbrowseBlock.style.display = 'none';
+    }
+});

--- a/hugo/assets/js/contact_form.js
+++ b/hugo/assets/js/contact_form.js
@@ -1,0 +1,34 @@
+document.addEventListener('DOMContentLoaded', function () {
+    const form = document.querySelector('.needs-validation');
+    const formAlert = document.getElementById('formAlert');
+    const reCAPTCHAAlert = document.getElementById('reCAPTCHAAlert');
+
+    form.addEventListener('submit', function (event) {
+        const isFormValid = form.checkValidity();
+        const recaptchaValue = grecaptcha.getResponse();
+
+        if (!isFormValid || recaptchaValue === "") {
+            event.preventDefault();
+            event.stopPropagation();
+
+            if (!isFormValid) {
+                form.classList.add('was-validated');
+                formAlert.style.display = 'block';
+            } else {
+                formAlert.style.display = 'none';
+            }
+
+            if (recaptchaValue === "") {
+                reCAPTCHAAlert.style.display = 'block';
+            } else {
+                reCAPTCHAAlert.style.display = 'none';
+            }
+            grecaptcha.reset();
+
+        } else {
+            formAlert.style.display = 'none';
+            reCAPTCHAAlert.style.display = 'none';
+            // Form submission occurs now
+        }
+    });
+});

--- a/hugo/assets/js/gbif_map.js
+++ b/hugo/assets/js/gbif_map.js
@@ -1,0 +1,85 @@
+/*
+Creates a population map using the GBIF API and leaflet for a given species.
+*/
+
+document.addEventListener("DOMContentLoaded", function () {
+    const mapElement = document.getElementById('map');
+    const latitude = mapElement.getAttribute('data-latitude');
+    const longitude = mapElement.getAttribute('data-longitude');
+    const initialZoom = mapElement.getAttribute('data-initial-zoom');
+    const gbifTaxonId = mapElement.getAttribute('data-gbif-taxon-id');
+
+    const map = L.map('map', {
+        minZoom: 1,
+        maxZoom: 15,
+    }).setView([latitude, longitude], initialZoom);
+
+    map.attributionControl.setPrefix('<a href="https://leafletjs.com" title="A JavaScript library for interactive maps">Leaflet</a>')
+
+    // Add the map tile layer from GBIF
+    // format is: https://tile.gbif.org/{srs}/{tileset}/{z}/{x}/{y}{format}{params}
+    const baseLayer = L.tileLayer('https://tile.gbif.org/3857/omt/{z}/{x}/{y}@1x.png?style=gbif-geyser-en', {
+        attribution: 'Map data &copy; <a href="https://www.openstreetmap.org/">OpenStreetMap</a> contributors',
+        maxZoom: 15,
+    }).addTo(map);
+
+    // add the GBIF occurrence overlay
+    const gbifUrl = `https://api.gbif.org/v2/map/occurrence/density/{z}/{x}/{y}@1x.png?srs=EPSG%3A3857&taxonKey=${gbifTaxonId}&style=blue.marker&year=2000,2099`;
+    const gbifAttrib = '<a href="https://www.gbif.org">GBIF</a>';
+
+    const gbifLayer = L.tileLayer(gbifUrl, {
+        minZoom: 1,
+        maxZoom: 15,
+        zoomOffset: -1,
+        tileSize: 512,
+        attribution: gbifAttrib
+    }).addTo(map);
+
+    // event listeners for api errors
+    let mapError = false;
+    baseLayer.on('tileerror', function (error) {
+        mapError = true;
+    });
+    gbifLayer.on('tileerror', function (error) {
+        mapError = true;
+    });
+
+    let hasRun = false;
+    gbifLayer.on('load', function () {
+        if (!hasRun) {
+            hasRun = true;
+
+            if (mapError) {
+                // Update map with a generic error message.
+                if (!document.querySelector('.map-error-message')) {
+                    const errorMessage = L.control({ position: 'bottomright' });
+
+                    errorMessage.onAdd = function (map) {
+                        const div = L.DomUtil.create('div', 'map-error-message');
+                        div.innerHTML = '<h1>The distribution map is temporarily unavailable</h1>';
+                        return div;
+                    };
+                    errorMessage.addTo(map);
+                }
+            } else {
+                // Add a help button, when clicked, toast pop-up happens.
+                const helpControl = L.control({ position: 'topright' });
+                const helpButtonHTML = '<button class="btn btn-light" id="helpButton" style="font-size: 1.3rem"><img src="/img/icons/question.svg" alt="Help button" class="scilife-icons-xl"></button>';
+
+                helpControl.onAdd = function (map) {
+                    let div = L.DomUtil.create('div', 'help-control');
+                    div.innerHTML = helpButtonHTML;
+                    return div;
+                };
+
+                helpControl.addTo(map);
+
+                document.getElementById('helpButton').addEventListener('click', function () {
+                    document.querySelectorAll('.toast').forEach(function (toast) {
+                        toast.classList.add('show');
+                    });
+                });
+            }
+        }
+    });
+});

--- a/hugo/assets/js/init_datatables.js
+++ b/hugo/assets/js/init_datatables.js
@@ -1,0 +1,24 @@
+/*
+Find tables on a page marked as wanting to be datatables and adds event listeners to them.
+Tables with data-table="true" attribute are made into datatables.
+*/
+
+document.addEventListener('DOMContentLoaded', function() {
+    var tables = document.querySelectorAll('table[data-table="true"]');
+    tables.forEach(function(table) {
+
+        // Table customisation options
+        var info = table.getAttribute('data-info') === 'true' ? true : false;
+        var ordering = table.getAttribute('data-ordering') === 'true' ? true : false;
+        var paging = table.getAttribute('data-paging') === 'true' ? true : false;
+        var searching = table.getAttribute('data-searching') === 'true' ? true : false;
+
+        var tableName = '#' + table.id;
+        new DataTable(tableName, {
+            info: info,
+            ordering: ordering,
+            paging: paging,
+            searching: searching
+        });
+    });
+});

--- a/hugo/assets/js/matomo.js
+++ b/hugo/assets/js/matomo.js
@@ -1,0 +1,12 @@
+/* Matomo tracking setup located in the footer of each page */
+var _paq = window._paq = window._paq || [];
+_paq.push(["disableCookies"]);
+_paq.push(['trackPageView']);
+_paq.push(['enableLinkTracking']);
+(function () {
+    var u = "//matomo.dc.scilifelab.se/";
+    _paq.push(['setTrackerUrl', u + 'matomo.php']);
+    _paq.push(['setSiteId', '11']);
+    var d = document, g = d.createElement('script'), s = d.getElementsByTagName('script')[0];
+    g.async = true; g.src = u + 'matomo.js'; s.parentNode.insertBefore(g, s);
+})();

--- a/hugo/assets/js/recaptcha.js
+++ b/hugo/assets/js/recaptcha.js
@@ -1,8 +1,0 @@
-/*
-Google reCAPTCHA v2 callback
-*/
-var onloadCallback = function () {
-    grecaptcha.render(id = "recaptcha-widget", {
-        'sitekey': '6LfLRQMqAAAAACSectjtigWkNvif1G2J8EFlj1nV'
-    });
-};

--- a/hugo/assets/js/recaptcha.js
+++ b/hugo/assets/js/recaptcha.js
@@ -1,0 +1,8 @@
+/*
+Google reCAPTCHA v2 callback
+*/
+var onloadCallback = function () {
+    grecaptcha.render(id = "recaptcha-widget", {
+        'sitekey': '6LfLRQMqAAAAACSectjtigWkNvif1G2J8EFlj1nV'
+    });
+};

--- a/hugo/assets/js/toggle_tables.js
+++ b/hugo/assets/js/toggle_tables.js
@@ -1,0 +1,27 @@
+/*
+Add toggle to swap between the long and short tables on each species download page.
+*/
+
+document.addEventListener('DOMContentLoaded', function () {
+    const checkbox = document.getElementById('flexSwitchCheckChecked');
+    const longTable = document.getElementById('table-container-long');
+    const shortTable = document.getElementById('table-container-short');
+
+    if (!checkbox || !longTable || !shortTable) {
+        console.error('Required elements not found');
+        return;
+    }
+
+    checkbox.addEventListener('change', function () {
+        if (this.checked) {
+            longTable.style.display = 'none';
+            shortTable.style.display = 'block';
+        } else {
+            longTable.style.display = 'block';
+            shortTable.style.display = 'none';
+        }
+    });
+
+    // Initial state setup
+    checkbox.dispatchEvent(new Event('change'));
+});

--- a/hugo/layouts/_default/baseof.html
+++ b/hugo/layouts/_default/baseof.html
@@ -51,8 +51,11 @@
 
         <!-- Any page specific scripts included here. -->
         {{ block "script_includes" . }} {{ end }}
-    </head>
 
+        <!-- Matomo tracking - Matomo recommends having it immediately before the closing </head> tag -->
+        {{ $matomoJS := resources.Get "js/matomo.js" | fingerprint | minify }}
+        <script src="{{ $matomoJS.RelPermalink }}"></script>
+    </head>
 
 
     <body class="d-flex flex-column min-vh-100">

--- a/hugo/layouts/contact/list.html
+++ b/hugo/layouts/contact/list.html
@@ -8,18 +8,8 @@
 
 {{ define "script_includes" }}
 
-<!--
-    Google recapatcha V2 implementation:
-    These scripts work with the contact_form.html and contact_form.js files to prevent form submission if not verified.
-    Docs: https://developers.google.com/recaptcha/docs/display
-
-    Note that the "onloadCallback" function needs to be loaded before reCAPTCHA API to avoid race conditions.
-    The reCAPTCHA API calls the "onloadCallback" function so it needs to be ready when the API calls it.
--->
-{{ $recaptchaJS := resources.Get "js/recaptcha.js" | fingerprint | minify }}
-<script src="{{ $recaptchaJS.RelPermalink }}"></script>
-
-<script src="https://www.google.com/recaptcha/api.js?onload=onloadCallback&render=explicit" async defer></script>
+<!-- Google recapatcha V2 -->
+ <script src="https://www.google.com/recaptcha/api.js" async defer></script>
 
 <!-- For submission of contact form -->
 {{ $contactFormJS := resources.Get "js/contact_form.js" | fingerprint | minify }}

--- a/hugo/layouts/contact/list.html
+++ b/hugo/layouts/contact/list.html
@@ -8,8 +8,15 @@
 
 {{ define "script_includes" }}
 
-<!-- Load the Google reCAPTCHA API asynchronously and defer its execution until the page has finished parsing -->
+<!-- onload callback function needs to be loaded before reCAPTCHA API to avoid race conditions. -->
+{{ $recaptchaJS := resources.Get "js/recaptcha.js" | fingerprint | minify }}
+<script src="{{ $recaptchaJS.RelPermalink }}"></script>
+
 <script src="https://www.google.com/recaptcha/api.js?onload=onloadCallback&render=explicit" async defer></script>
+
+<!-- For submission of contact form -->
+{{ $contactFormJS := resources.Get "js/contact_form.js" | fingerprint | minify }}
+<script src="{{ $contactFormJS.RelPermalink }}"></script>
 
 {{ end }}
 
@@ -23,14 +30,5 @@
         </div>
     </div>
 </div>
-
-
-<script type="text/javascript">
-    var onloadCallback = function () {
-        grecaptcha.render(id = "recaptcha-widget", {
-            'sitekey': '6LfLRQMqAAAAACSectjtigWkNvif1G2J8EFlj1nV'
-        });
-    };
-</script>
 
 {{ end }}

--- a/hugo/layouts/contact/list.html
+++ b/hugo/layouts/contact/list.html
@@ -8,7 +8,14 @@
 
 {{ define "script_includes" }}
 
-<!-- onload callback function needs to be loaded before reCAPTCHA API to avoid race conditions. -->
+<!--
+    Google recapatcha V2 implementation:
+    These scripts work with the contact_form.html and contact_form.js files to prevent form submission if not verified.
+    Docs: https://developers.google.com/recaptcha/docs/display
+
+    Note that the "onloadCallback" function needs to be loaded before reCAPTCHA API to avoid race conditions.
+    The reCAPTCHA API calls the "onloadCallback" function so it needs to be ready when the API calls it.
+-->
 {{ $recaptchaJS := resources.Get "js/recaptcha.js" | fingerprint | minify }}
 <script src="{{ $recaptchaJS.RelPermalink }}"></script>
 

--- a/hugo/layouts/genome-browser/list.html
+++ b/hugo/layouts/genome-browser/list.html
@@ -1,3 +1,14 @@
+{{ define "script_includes" }}
+
+<!-- Check if the config file exists - if not display error message -->
+{{ $configCheckJS := resources.Get "js/check_for_config.js" | fingerprint | minify }}
+<script src="{{ $configCheckJS.RelPermalink }}"></script>
+
+<script defer src="/browser/static/js/main.js"></script>
+
+{{ end }}
+
+
 {{ define "main" }}
 
 <div class="container-fluid mt-3">
@@ -29,32 +40,5 @@
     </script>
 {{ end }}
 
-<!-- Check if the config file exists before loading JBrowse2 -->
-<script>
-    document.addEventListener('DOMContentLoaded', async function() {
-        const urlParams = new URLSearchParams(window.location.search);
-        const configFile = urlParams.get('config');
-
-
-        if (!configFile) {
-            document.getElementById('no-config').style.display = 'block';
-            return;
-        }
-
-        try {
-            const response = await fetch(configFile);
-            if (response.ok) {
-                const script = document.createElement('script');
-                script.defer = true;
-                script.src = '/browser/static/js/main.js';
-                document.head.appendChild(script);
-            } else {
-                document.getElementById('no-config').style.display = 'block';
-            }
-        } catch (error) {
-            document.getElementById('no-config').style.display = 'block';
-        }
-    });
-</script>
 
 {{ end }}

--- a/hugo/layouts/glossary/list.html
+++ b/hugo/layouts/glossary/list.html
@@ -31,7 +31,7 @@
         <div class="table-responsive">
             {{ with resources.Get "glossary.csv" }}
                 {{ with . | transform.Unmarshal (dict "delimiter" "|" "lazyQuotes" true) }}
-                <table id="glossaryTable" class="table table-hover table-bordered">
+                <table id="glossaryTable" class="table table-hover table-bordered" data-table="true" data-searching="true">
                     <thead class="table-light">
                         <tr>
                             {{ range index . 0 }}
@@ -116,16 +116,5 @@
 
 
 </div>
-
-<script>
-    document.addEventListener('DOMContentLoaded', function() {
-        new DataTable('#glossaryTable', {
-            info: false,
-            ordering: false,
-            paging: false,
-            searching: true
-        });
-    });
-</script>
 
 {{ end }}

--- a/hugo/layouts/partials/add_datatables_jquery.html
+++ b/hugo/layouts/partials/add_datatables_jquery.html
@@ -1,3 +1,11 @@
+<!-- dependancies -->
 <script src="https://code.jquery.com/jquery-3.7.1.min.js" integrity="sha256-/JqT3SQfawRcv/BIHPThkBvs0OEvtFFmqPF/lYI/Cxo=" crossorigin="anonymous"> </script>
 <link rel="stylesheet" href="https://cdn.datatables.net/2.1.8/css/dataTables.dataTables.css" integrity="sha256-4hHaMf5CR1wPHcp6GUIDIR7CE2se3xdqoAWigV63YEw=" crossorigin="anonymous">
 <script src="https://cdn.datatables.net/2.1.8/js/dataTables.js" integrity="sha256-PSmeeEFHx/Xs2Jb23S6XwbhgCh7n1HGv8NnLtZhSiDA=" crossorigin="anonymous"></script>
+
+<!--
+    Find and init datatables located on the page.
+    Tables with data-table="true" attribute are made into datatables.
+-->
+{{ $initDatatablesJS := resources.Get "js/init_datatables.js" | fingerprint | minify }}
+<script src="{{ $initDatatablesJS.RelPermalink }}"></script>

--- a/hugo/layouts/partials/distrib_map.html
+++ b/hugo/layouts/partials/distrib_map.html
@@ -1,5 +1,15 @@
+<!--
+    Partial to create a leaflet map with GBIF observation data overlaid for a given species
+-->
 <figure>
-    <div id="map" class="scilife-intro-map-img z-2"></div>
+    <div id="map" class="scilife-intro-map-img z-2"
+        data-latitude="{{ .Params.latitude | default 0 }}"
+        data-longitude="{{ .Params.longitude | default 0 }}"
+        data-initial-zoom="{{ .Params.initialZoom | default 1 }}"
+        data-gbif-taxon-id="{{ .Params.gbif_taxon_id }}">
+    </div>
+
+    <div id="map"></div>
     <figcaption class="scilife-card-image-attrib">
         <a href="https://www.gbif.org/species/{{ .Params.gbif_taxon_id }}" target="_blank">
             Recorded observations of the species from the year 2000 onwards. Map generated using GBIF <i
@@ -33,89 +43,3 @@
         </p>
     </div>
 </div>
-
-
-<!-- Leaflet observation map script -->
-{{ $latitude := .Params.latitude | default 0 }}
-{{ $longitude := .Params.longitude | default 0 }}
-{{ $initialZoom := .Params.initialZoom | default 1 }}
-
-<script>
-    document.addEventListener("DOMContentLoaded", function() {
-        const map = L.map('map', {
-            minZoom: 1,
-            maxZoom: 15,
-        }).setView(
-            ["{{ $latitude }}", "{{ $longitude }}"],
-            "{{ $initialZoom }}");
-
-        map.attributionControl.setPrefix('<a href="https://leafletjs.com" title="A JavaScript library for interactive maps">Leaflet</a>')
-
-        // Add the map tile layer from GBIF
-        // format is: https://tile.gbif.org/{srs}/{tileset}/{z}/{x}/{y}{format}{params}
-        const baseLayer = L.tileLayer('https://tile.gbif.org/3857/omt/{z}/{x}/{y}@1x.png?style=gbif-geyser-en', {
-            attribution: 'Map data &copy; <a href="https://www.openstreetmap.org/">OpenStreetMap</a> contributors',
-            maxZoom: 15,
-        }).addTo(map);
-
-        // add the GBIF occurrence overlay
-        const gbifUrl = 'https://api.gbif.org/v2/map/occurrence/density/{z}/{x}/{y}@1x.png?srs=EPSG%3A3857&taxonKey={{ .Params.gbif_taxon_id }}&style=blue.marker&year=2000,2099';
-        const gbifAttrib = '<a href="https://www.gbif.org">GBIF</a>';
-
-        const gbifLayer = L.tileLayer(gbifUrl, {
-            minZoom: 1,
-            maxZoom: 15,
-            zoomOffset: -1,
-            tileSize: 512,
-            attribution: gbifAttrib
-        }).addTo(map);
-
-        // event listeners for api errors
-        let mapError = false;
-        baseLayer.on('tileerror', function(error) {
-            mapError = true;
-        });
-        gbifLayer.on('tileerror', function(error) {
-            mapError = true;
-        });
-
-        let hasRun = false;
-        gbifLayer.on('load', function() {
-            if (!hasRun) {
-                hasRun = true;
-
-                if (mapError) {
-                    // Update map with a generic error message.
-                    if (!document.querySelector('.map-error-message')) {
-                        const errorMessage = L.control({ position: 'bottomright' });
-
-                        errorMessage.onAdd = function(map) {
-                            const div = L.DomUtil.create('div', 'map-error-message');
-                            div.innerHTML = '<h1>The distribution map is temporarily unavailable</h1>';
-                            return div;
-                        };
-                        errorMessage.addTo(map);
-                    }
-                } else {
-                    // Add a help button, when clicked, toast pop-up happens.
-                    const helpControl = L.control({ position: 'topright' });
-                    const helpButtonHTML = '<button class="btn btn-light" id="helpButton" style="font-size: 1.3rem"><img src="/img/icons/question.svg" alt="Help button" class="scilife-icons-xl"></button>';
-
-                    helpControl.onAdd = function (map) {
-                        let div = L.DomUtil.create('div', 'help-control');
-                        div.innerHTML = helpButtonHTML;
-                        return div;
-                    };
-
-                    helpControl.addTo(map);
-
-                    document.getElementById('helpButton').addEventListener('click', function() {
-                        document.querySelectorAll('.toast').forEach(function(toast) {
-                            toast.classList.add('show');
-                        });
-                    });
-                }
-            }
-        });
-    });
-</script>

--- a/hugo/layouts/partials/download_table.html
+++ b/hugo/layouts/partials/download_table.html
@@ -4,7 +4,7 @@
 {{ $aliasFileURL := .aliasFileURL }}
 
 <div class="table-responsive">
-    <table id="downloadTable{{ $tableType | title}}" class="table table-hover table-bordered">
+    <table id="downloadTable{{ $tableType | title}}" class="table table-hover table-bordered" data-table="true" data-ordering="true">
         <thead class="table-light">
             <tr style="white-space: nowrap;">
                 <th>Data track name</th>
@@ -115,14 +115,3 @@
       </caption>
     </div>
 </div>
-
-<script>
-    document.addEventListener('DOMContentLoaded', function() {
-        new DataTable('#downloadTable{{ $tableType | title}}', {
-            info: false,
-            ordering: true,
-            paging: false,
-            searching: false
-        });
-    });
-</script>

--- a/hugo/layouts/partials/footer.html
+++ b/hugo/layouts/partials/footer.html
@@ -79,17 +79,5 @@
 </footer>
 
 <!-- Matomo tracking info -->
-<script>
-    var _paq = window._paq = window._paq || [];
-    /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-    _paq.push(["disableCookies"]);
-    _paq.push(['trackPageView']);
-    _paq.push(['enableLinkTracking']);
-    (function () {
-        var u = "//matomo.dc.scilifelab.se/";
-        _paq.push(['setTrackerUrl', u + 'matomo.php']);
-        _paq.push(['setSiteId', '11']);
-        var d = document, g = d.createElement('script'), s = d.getElementsByTagName('script')[0];
-        g.async = true; g.src = u + 'matomo.js'; s.parentNode.insertBefore(g, s);
-    })();
-</script>
+{{ $matomoJS := resources.Get "js/matomo.js" | fingerprint | minify }}
+<script src="{{ $matomoJS.RelPermalink }}"></script>

--- a/hugo/layouts/partials/footer.html
+++ b/hugo/layouts/partials/footer.html
@@ -77,7 +77,3 @@
 
     </div>
 </footer>
-
-<!-- Matomo tracking info -->
-{{ $matomoJS := resources.Get "js/matomo.js" | fingerprint | minify }}
-<script src="{{ $matomoJS.RelPermalink }}"></script>

--- a/hugo/layouts/shortcodes/contact_form.html
+++ b/hugo/layouts/shortcodes/contact_form.html
@@ -85,39 +85,3 @@
     <button type="submit" class="btn btn-primary mb-3" aria-label="Submit the form">Submit</button>
 
 </form>
-
-<script>
-    const form = document.querySelector('.needs-validation');
-    const formAlert = document.getElementById('formAlert');
-    const reCAPTCHAAlert = document.getElementById('reCAPTCHAAlert');
-
-    form.addEventListener('submit', function (event) {
-        const isFormValid = form.checkValidity();
-        const recaptchaValue = grecaptcha.getResponse();
-
-        if (!isFormValid || recaptchaValue === "") {
-            event.preventDefault();
-            event.stopPropagation();
-
-            if (!isFormValid) {
-                form.classList.add('was-validated');
-                formAlert.style.display = 'block';
-            } else {
-                formAlert.style.display = 'none';
-            }
-
-            if (recaptchaValue === "") {
-                reCAPTCHAAlert.style.display = 'block';
-            } else {
-                reCAPTCHAAlert.style.display = 'none';
-            }
-            grecaptcha.reset();
-
-        } else {
-            formAlert.style.display = 'none';
-            reCAPTCHAAlert.style.display = 'none';
-            // Form submission occurs now
-        }
-    });
-
-</script>

--- a/hugo/layouts/species/species_download.html
+++ b/hugo/layouts/species/species_download.html
@@ -8,9 +8,11 @@
 {{ define "script_includes" }}
 
 {{ partial "add_datatables_jquery.html" . }}
+<!-- Toggle between long and short form of download load table -->
+{{ $tableToggleJS := resources.Get "js/toggle_tables.js" | fingerprint | minify }}
+<script src="{{ $tableToggleJS.RelPermalink }}"></script>
 
 {{ end }}
-
 
 
 {{ define "main" }}
@@ -75,33 +77,6 @@
 
 {{ partial "last_updated.html" . }}
 
-<script>
-    document.getElementById('flexSwitchCheckChecked').addEventListener('change', function() {
-        const longTable = document.getElementById('table-container-long');
-        const shortTable = document.getElementById('table-container-short');
 
-        if (this.checked) {
-            longTable.style.display = 'none';
-            shortTable.style.display = 'block';
-        } else {
-            longTable.style.display = 'block';
-            shortTable.style.display = 'none';
-        }
-
-        // Initialize DataTables if not already initialized
-        if (!document.querySelector('#downloadTableLong').classList.contains('dataTable')) {
-            new DataTable('#downloadTableLong');
-        }
-        if (!document.querySelector('#downloadTableShort').classList.contains('dataTable')) {
-            new DataTable('#downloadTableShort');
-        }
-    });
-
-    // Initial state setup
-    document.addEventListener('DOMContentLoaded', function() {
-        const checkbox = document.getElementById('flexSwitchCheckChecked');
-        checkbox.dispatchEvent(new Event('change'));
-    });
-</script>
 
 {{ end }}

--- a/hugo/layouts/species/species_intro.html
+++ b/hugo/layouts/species/species_intro.html
@@ -13,6 +13,9 @@ integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin=""/>
 <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
 integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin="" defer></script>
 
+{{ $gbifMap := resources.Get "js/gbif_map.js" | fingerprint | minify }}
+<script src="{{ $gbifMap.RelPermalink }}" defer></script>
+
 {{ end }}
 
 
@@ -156,11 +159,6 @@ integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin="" d
 
     </div>
 
-
-
-    <div class="row">
-
-    </div>
 
     <div class="row">
         <div class="col scilife-subsection mt-3">

--- a/scripts/dockerserve
+++ b/scripts/dockerserve
@@ -16,7 +16,7 @@
 : "${SWG_DATA_DIR:=data}"
 : "${SWG_PORT:=8080}"
 : "${SWG_HUGO_IMAGE:=hugomods/hugo}"
-: "${SWG_HUGO_TAG:=std-base-0.128.2}"
+: "${SWG_HUGO_TAG:=std-base-0.138.0}"
 
 if [[ -n "${cid:=$(docker ps -qaf name=${SWG_NAME})}" ]]; then
     cat <<EOF


### PR DESCRIPTION
This PR is about adding a [content security policy](https://web.dev/articles/csp) to the website. 

This essentially involves removing inline JS and creating a whitelist inside the `docker/nginx-custom.conf` for all the external connections we expect to make.

The genome browser page posed some extra challenges when creating this:

1. In order to remove `'unsafe-inline'` from  the `script-src` line required updating each species `config.json` to disable [google analytics](https://jbrowse.org/jb2/docs/config_guides/disable_analytics/). Just whitelisting google analytics webpages did not work. 
2. Trying to remove `'unsafe-inline'` from  `style-src` was unsuccessful because JBrowse relies on it. I think it is okay to leave `'unsafe-inline'` in `style-src`and we can be happy we got the rest. 

@brinkdp  and I already spoke and he is working on including the disable google analytics param in the `config.json` for any future species. (If the param is not included the browser page still works as expected, you just see some errors if you open up the console). 