### PR TITLE
EB-377: CLI improvements to docker wrapper scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,14 +154,14 @@ Then to run the website locally, you have several options
 
 ```bash
 docker pull ghcr.io/scilifelabdatacentre/swg-hugo-site:dev
-./scripts/dockerserve
+./scripts/dockerserve -t dev
 ```
 
 #### Using a local build
 
 ```bash
-./scripts/dockerbuild hugo
-SWG_TAG=local ./scripts/dockerserve
+./scripts/dockerbuild -t local hugo
+./scripts/dockerserve -t local
 ```
 
 #### Using the Hugo development server
@@ -174,7 +174,7 @@ bundle in `hugo/static/browser`
 
 ```bash
 ./scripts/download_jbrowse v2.15.4 hugo/static/browser
-scripts/dockerserve --dev
+./scripts/dockerserve -d
 ```
 
 ---

--- a/playwright/Running_Playwright.md
+++ b/playwright/Running_Playwright.md
@@ -32,7 +32,7 @@ python -m playwright install
 
 ```bash
 ./scripts/dockerbuild hugo
-SWG_TAG=local ./scripts/dockerserve
+./scripts/dockerserve -t local
 ```
 
 **4. Run the tests**

--- a/scripts/dockerbuild
+++ b/scripts/dockerbuild
@@ -35,8 +35,13 @@ main () {
   declare -a build_args
 
   kind=data
-  tag=local
-  use_host_uid=1
+  # Support SWG-prefixed environment variables for backward compatibility
+  tag="${SWG_TAG:-local}"
+  if [[ -z "${SWG_DEFAULT_USER}" ]]; then
+    use_host_uid=1
+  else
+    use_host_uid=0
+  fi
   dry_run=0
 
   while getopts k:t:udh opt; do

--- a/scripts/dockerbuild
+++ b/scripts/dockerbuild
@@ -12,33 +12,33 @@ _DEFAULT_TAG=local
 declare -a _BUILD_ARGS
 
 docker_build () {
-    docker build "${_BUILD_ARGS[@]}" \
-	   -t "${SWG_IMAGE:-$_DEFAULT_IMAGE}:${SWG_TAG:-$_DEFAULT_TAG}" \
-	   -f "${SWG_DOCKERFILE:-$_DEFAULT_DOCKERFILE}" .
+  docker build "${_BUILD_ARGS[@]}" \
+         -t "${SWG_IMAGE:-$_DEFAULT_IMAGE}:${SWG_TAG:-$_DEFAULT_TAG}" \
+         -f "${SWG_DOCKERFILE:-$_DEFAULT_DOCKERFILE}" .
 }
 
 if [[ -z "$1" || "$1" == "data" ]];
 then
-    _DEFAULT_IMAGE=ghcr.io/scilifelabdatacentre/swg-data-builder
-    _DEFAULT_DOCKERFILE=docker/data.dockerfile
-    if [[ -z ${SWG_DEFAULT_USER} ]];then
-	_BUILD_ARGS+=("--build-arg" "SWG_UID=$(id -u)")
-	_BUILD_ARGS+=("--build-arg" "SWG_GID=$(id -g)")
-    fi
-    docker_build && exit 0
+  _DEFAULT_IMAGE=ghcr.io/scilifelabdatacentre/swg-data-builder
+  _DEFAULT_DOCKERFILE=docker/data.dockerfile
+  if [[ -z ${SWG_DEFAULT_USER} ]];then
+    _BUILD_ARGS+=("--build-arg" "SWG_UID=$(id -u)")
+    _BUILD_ARGS+=("--build-arg" "SWG_GID=$(id -g)")
+  fi
+  docker_build && exit 0
 fi
 
 
 
 if [[ "$1" = hugo ]]; then
-    _DEFAULT_IMAGE=ghcr.io/scilifelabdatacentre/swg-hugo-site
-    _DEFAULT_DOCKERFILE=docker/hugo.dockerfile
-    # CI context
-    _BUILD_ARGS+=(
-	"--build-arg" "HUGO_GIT_REF_NAME=${HUGO_GIT_REF_NAME:-$(git branch --show-current)}"
-	"--build-arg" "HUGO_GIT_SHA=${HUGO_GIT_SHA:-$(git rev-parse HEAD)}"
-    )
-    docker_build  && exit 0
+  _DEFAULT_IMAGE=ghcr.io/scilifelabdatacentre/swg-hugo-site
+  _DEFAULT_DOCKERFILE=docker/hugo.dockerfile
+  # CI context
+  _BUILD_ARGS+=(
+    "--build-arg" "HUGO_GIT_REF_NAME=${HUGO_GIT_REF_NAME:-$(git branch --show-current)}"
+    "--build-arg" "HUGO_GIT_SHA=${HUGO_GIT_SHA:-$(git rev-parse HEAD)}"
+  )
+  docker_build  && exit 0
 fi
 
 echo "Usage: ./scripts/dockerbuild.sh [data | hugo]" && exit 1

--- a/scripts/dockerbuild
+++ b/scripts/dockerbuild
@@ -4,14 +4,15 @@ help() {
   echo "\
 Build the Genome Portal Docker images
 
-Usage: dockerbuild [-k data|hugo ] [-t TAG] [-i IMAGE] [-u]
+Usage: dockerbuild [-h] [-k data|hugo ] [-t TAG] [-i IMAGE] [-u]
 
 Options:
+  -h            Display this help message and exit
   -k KIND       Kind of image to build, 'data' (the default) or 'hugo'.
   -t TAG        Docker tag
   -i IMAGE      Docker image name. Defaults: ghcr.io/scilifelabdatacentre/{swg-data-builder,swg-hugo-site}
   -u            Use default user and group IDs in the data builder image (see below)
-  -d            Dry run, prints the arguments passed to the Docker run command
+  -d            Dry run, print the Docker build command
 
 Data builder (docker/data.dockerfile):
 
@@ -44,14 +45,14 @@ main () {
   fi
   dry_run=0
 
-  while getopts k:t:udh opt; do
+  while getopts k:t:unh opt; do
     case "${opt}" in
-      h) help && exit 0 ;;
-      \?) help && exit 1 ;;
       k) kind="${OPTARG}" ;;
       t) tag="${OPTARG}" ;;
       u) use_host_uid=0 ;;
-      d) dry_run=1 ;;
+      n) dry_run=1 ;;
+      h) help && exit 0 ;;
+      \?) >&2 help && exit 1 ;;
     esac
   done
 
@@ -77,17 +78,15 @@ main () {
     exit 1
   fi
 
-  if ! ((dry_run)); then
-    docker_build
-  else
-    echo "Build arguments: ${build_args[*]}"
-    echo "Image:           ${image}:${tag}"
-    echo "Dockerfile:      ${dockerfile}"
-  fi
+  docker_build
 }
 
 docker_build () {
-  docker build "${build_args[@]}" \
+  cmd="docker build"
+  if ((dry_run)); then
+    cmd="echo ${cmd}"
+  fi
+  ${cmd} "${build_args[@]}" \
          -t "${image}:${tag}" \
          -f "${dockerfile}" .
 }

--- a/scripts/dockerbuild
+++ b/scripts/dockerbuild
@@ -1,46 +1,91 @@
 #!/bin/bash
 
-# Helper script to build Docker images
-#
-# By default, the host user ID and group ID are forwarded through
-# build arguments. To disable this behavior and use the dockerfile
-# defaults, set the SWG_DEFAULT_USER environment variable to 1.
-#
-# The hugo image can be built with several optional build arguments:
-# These can be used to control the version information shown on the footer of each page.
-_DEFAULT_TAG=local
-declare -a _BUILD_ARGS
+help() {
+  echo "\
+Build the Genome Portal Docker images
 
-docker_build () {
-  docker build "${_BUILD_ARGS[@]}" \
-         -t "${SWG_IMAGE:-$_DEFAULT_IMAGE}:${SWG_TAG:-$_DEFAULT_TAG}" \
-         -f "${SWG_DOCKERFILE:-$_DEFAULT_DOCKERFILE}" .
+Usage: dockerbuild [-k data|hugo ] [-t TAG] [-i IMAGE] [-u]
+
+Options:
+  -k KIND       Kind of image to build, 'data' (the default) or 'hugo'.
+  -t TAG        Docker tag
+  -i IMAGE      Docker image name. Defaults: ghcr.io/scilifelabdatacentre/{swg-data-builder,swg-hugo-site}
+  -u            Use default user and group IDs in the data builder image (see below)
+  -d            Dry run, prints the arguments passed to the Docker run command
+
+Data builder (docker/data.dockerfile):
+
+By default, user ID and group ID used in the image are made to match
+those of the host, so that files created in mounted directories get
+convenient permissions. To disable this behavior and use the
+dockerfile defaults, use the -u flag or set the SWG_DEFAULT_USER
+environment variable to 1.
+
+Hugo (docker/hugo.dockerfile):
+
+The HUGO_GIT_REF_NAME and HUGO_GIT_SHA environment variables can be
+set to control the version information shown on the footer of each
+page They both default to the checked out branch name and commit hash
+respectively.
+"
 }
 
-if [[ -z "$1" || "$1" == "data" ]];
-then
-  _DEFAULT_IMAGE=ghcr.io/scilifelabdatacentre/swg-data-builder
-  _DEFAULT_DOCKERFILE=docker/data.dockerfile
-  if [[ -z ${SWG_DEFAULT_USER} ]];then
-    _BUILD_ARGS+=("--build-arg" "SWG_UID=$(id -u)")
-    _BUILD_ARGS+=("--build-arg" "SWG_GID=$(id -g)")
+main () {
+  local kind tag image use_host_uid dry_run
+  declare -a build_args
+
+  kind=data
+  tag=local
+  use_host_uid=1
+  dry_run=0
+
+  while getopts k:t:udh opt; do
+    case "${opt}" in
+      h) help && exit 0 ;;
+      \?) help && exit 1 ;;
+      k) kind="${OPTARG}" ;;
+      t) tag="${OPTARG}" ;;
+      u) use_host_uid=0 ;;
+      d) dry_run=1 ;;
+    esac
+  done
+
+  if [[ "${kind}" == data ]]; then
+    image=ghcr.io/scilifelabdatacentre/swg-data-builder
+    dockerfile=docker/data.dockerfile
+    if ((use_host_uid)); then
+      build_args=(
+        "--build-arg" "SWG_UID=$(id -u)"
+        "--build-arg" "SWG_GID=$(id -g)"
+      )
+    fi
+  elif [[ "${kind}" == hugo ]]; then
+    image=ghcr.io/scilifelabdatacentre/swg-hugo-site
+    dockerfile=docker/hugo.dockerfile
+    build_args=(
+      "--build-arg" "HUGO_GIT_REF_NAME=${HUGO_GIT_REF_NAME:-$(git branch --show-current)}"
+      "--build-arg" "HUGO_GIT_SHA=${HUGO_GIT_SHA:-$(git rev-parse HEAD)}"
+    )
+  else
+    >&2 echo "Argument to option -k must be either 'data' or 'hugo'"
+    >&2 help
+    exit 1
   fi
-  docker_build && exit 0
-fi
 
+  if ! ((dry_run)); then
+    docker_build
+  else
+    echo "Build arguments: ${build_args[*]}"
+    echo "Image:           ${image}:${tag}"
+    echo "Dockerfile:      ${dockerfile}"
+  fi
+}
 
+docker_build () {
+  docker build "${build_args[@]}" \
+         -t "${image}:${tag}" \
+         -f "${dockerfile}" .
+}
 
-if [[ "$1" = hugo ]]; then
-  _DEFAULT_IMAGE=ghcr.io/scilifelabdatacentre/swg-hugo-site
-  _DEFAULT_DOCKERFILE=docker/hugo.dockerfile
-  # CI context
-  _BUILD_ARGS+=(
-    "--build-arg" "HUGO_GIT_REF_NAME=${HUGO_GIT_REF_NAME:-$(git branch --show-current)}"
-    "--build-arg" "HUGO_GIT_SHA=${HUGO_GIT_SHA:-$(git rev-parse HEAD)}"
-  )
-  docker_build  && exit 0
-fi
-
-echo "Usage: ./scripts/dockerbuild.sh [data | hugo]" && exit 1
-
+main "$@"
 

--- a/scripts/dockerbuild
+++ b/scripts/dockerbuild
@@ -4,15 +4,14 @@ help() {
   echo "\
 Build the Genome Portal Docker images
 
-Usage: dockerbuild [-h] [-k data|hugo ] [-t TAG] [-i IMAGE] [-u]
+Usage: dockerbuild [-h] [-k data|hugo ] [-t TAG] [-u]
 
 Options:
   -h            Display this help message and exit
   -k KIND       Kind of image to build, 'data' (the default) or 'hugo'.
   -t TAG        Docker tag
-  -i IMAGE      Docker image name. Defaults: ghcr.io/scilifelabdatacentre/{swg-data-builder,swg-hugo-site}
   -u            Use default user and group IDs in the data builder image (see below)
-  -d            Dry run, print the Docker build command
+  -n            Dry run, print the Docker build command
 
 Data builder (docker/data.dockerfile):
 

--- a/scripts/dockerbuild
+++ b/scripts/dockerbuild
@@ -82,9 +82,8 @@ main () {
 
 docker_build () {
   cmd="docker build"
-  if ((dry_run)); then
-    cmd="echo ${cmd}"
-  fi
+  ((dry_run)) && cmd="echo ${cmd}"
+
   ${cmd} "${build_args[@]}" \
          -t "${image}:${tag}" \
          -f "${dockerfile}" .

--- a/scripts/dockermake
+++ b/scripts/dockermake
@@ -31,9 +31,10 @@ main() {
 
   # Directories on the host that are mounted in the container, and used
   # by `make`. Paths must be *relative* to the repository root.
-  : ${SWG_DATA_DIR:="data"}
-  : ${SWG_INSTALL_DIR:="hugo/static/data"}
-  : ${SWG_CONFIG_DIR:="config"}
+  declare data_dir install_dir config_dir
+  data_dir="${SWG_DATA_DIR:=data}"
+  install_dir="${SWG_INSTALL_DIR:=hugo/static/data}"
+  config_dir="${SWG_CONFIG_DIR:=config}"
 
   declare -a docker_flags
 
@@ -50,9 +51,9 @@ main() {
       shift
     fi
 
-    SWG_DATA_DIR=tests/data
-    SWG_INSTALL_DIR=tests/public
-    SWG_CONFIG_DIR=tests/config
+    data_dir=tests/data
+    install_dir=tests/public
+    config_dir=tests/config
     SWG_FIXTURES_DIR=tests/fixtures
     _TEST_NET=swg-test-net
     _TEST_SERVER_NAME=fixtures
@@ -102,35 +103,40 @@ main() {
 # Mount Makefile and directories to use for data, configuration and
 # installation
 #
-# Globals:
-#   SWG_DATA_DIR
-#   SWG_INSTALL_DIR
-#   SWG_CONFIG_DIR
-#   SWG_IMAGE
-#   SWG_TAG
-#   CWD
+# Non-locals:
+#   data_dir
+#   install_dir
+#   config_dir
+#   image
+#   tag
+#   cwd
+#   docker_flags
 # Arguments:
-#   All passsed arguments are forwarded to `make`
+#   All arguments are passed to 'make'
 docker_make() {
   local -r docker_workdir='/swedgene'
   # Make sure writable directories exist on the host
-  mkdir -p "$SWG_DATA_DIR" "$SWG_INSTALL_DIR"
+  mkdir -p "${data_dir}" "${install_dir}"
 
-  # Build the docker argument list, specifying mount points and
-  # environment variables
-  for dir in SWG_DATA_DIR SWG_INSTALL_DIR SWG_CONFIG_DIR; do
-    # The ! in the parameter expansion introductes a level of
-    # indirection: the result is the value of the variable whose
-    # name is $dir
-    docker_flags+=(
-      -v "$CWD/${!dir}:$docker_workdir/${!dir}"
-      -e "$dir=${!dir}"
-    )
-  done
-  # Don't forget the Makefile and script directory
+  # Specify Docker mount points and environment variables used by make
   docker_flags+=(
-    -v "$CWD/Makefile:$docker_workdir/Makefile"
-    -v "$CWD/scripts:$docker_workdir/scripts"
+    # Data directory
+    -v "${CWD}/${data_dir}:${docker_workdir}/${data_dir}"
+    -e "SWG_DATA_DIR=${data_dir}"
+
+    # Installation directory
+    -v "${CWD}/${install_dir}:${docker_workdir}/${install_dir}"
+    -e "SWG_INSTALL_DIR=${install_dir}"
+
+    # Configuration directory
+    -v "${CWD}/${config_dir}:${docker_workdir}/${config_dir}"
+    -e "SWG_CONFIG_DIR=${config_dir}"
+  )
+
+  # Mount Makefile and script directory as well
+  docker_flags+=(
+    -v "${CWD}/Makefile:${docker_workdir}/Makefile"
+    -v "${CWD}/scripts:${docker_workdir}/scripts"
   )
   docker run --rm "${docker_flags[@]}" "${image}:${tag}" make "$@"
 }

--- a/scripts/dockermake
+++ b/scripts/dockermake
@@ -31,17 +31,19 @@ main() {
 
   # Directories on the host that are mounted in the container, and used
   # by `make`. Paths must be *relative* to the repository root.
-  declare data_dir install_dir config_dir
+  declare data_dir install_dir config_dir docker_user
   data_dir="${SWG_DATA_DIR:=data}"
   install_dir="${SWG_INSTALL_DIR:=hugo/static/data}"
   config_dir="${SWG_CONFIG_DIR:=config}"
+  docker_user="$(id -u):$(id -g)"
 
-  declare test no_teardown
-  while getopts hTkt: opt; do
+  declare test no_teardown docker_user
+  while getopts hTkt:u: opt; do
     case "${opt}" in
       T) test=1 ;;
       k) no_teardown=1 ;;
       t) tag="${OPTARG}" ;;
+      u) docker_user="${OPTARG}" ;;
       h) help && exit 0 ;;
       \?) >&2 help && exit 1 ;;
     esac
@@ -49,10 +51,8 @@ main() {
   shift $((OPTIND - 1))
 
   declare -a docker_flags
-  if [[ -n ${SWG_UID} || -n ${SWG_GID} ]];
-  then
-    docker_flags+=("-u" "${SWG_UID:-$(id -u)}:${SWG_GID:-$(id -g)}")
-  fi
+  docker_flags=("-u" "${docker_user}")
+
 
   if ((test)); then
 

--- a/scripts/dockermake
+++ b/scripts/dockermake
@@ -1,15 +1,26 @@
 #!/bin/bash
-#
-# Run `make` in a Docker container
-#
-# The environment variables SWG_UID and SWG_GID can be used to run the
-# container as a specific user and group. By default, the effective
-# user and group id of the host are used.
-#
-# The environment variables SWG_IMAGE and SWG_TAG can be
-# used to override the Docker image to use. For example:
-#
-# SWG_IMAGE=industrious-squirrel SWG_TAG=slim-buster scripts/dockerbuild.sh build
+
+help() {
+  echo "\
+Run 'make' in a Docker container
+
+Usage: dockermake [options] [arg...]
+
+Non-option command line arguments are passed to 'make'.
+
+The environment variables SWG_UID and SWG_GID can be used to run the
+container as a specific user and group. By default, the effective user
+and group id of the host are used.
+
+The environment variables SWG_IMAGE and SWG_TAG can be used to
+override the Docker image to use. For example:
+
+export SWG_IMAGE=industrious-squirrel SWG_TAG=slim-buster
+scripts/dockerbuild.sh build
+"
+
+}
+
 main() {
   CWD="$(pwd)"
   readonly CWD

--- a/scripts/dockermake
+++ b/scripts/dockermake
@@ -22,8 +22,7 @@ Options:
   -u  USER      Docker user, specified as '<USER>:<GROUP>'.
                 Default: host user and group IDs, so that files
                 created in mounted directories have convenient ownership.
-
-
+  -n            Dry run. Only print the make commands that would be issued.
 "
 
 }
@@ -38,25 +37,28 @@ main() {
 
   # Directories on the host that are mounted in the container, and used
   # by `make`. Paths must be *relative* to the repository root.
-  declare data_dir install_dir config_dir docker_user
+  declare data_dir install_dir config_dir docker_user dry_run
   data_dir="${SWG_DATA_DIR:=data}"
   install_dir="${SWG_INSTALL_DIR:=hugo/static/data}"
   config_dir="${SWG_CONFIG_DIR:=config}"
   docker_user="$(id -u):$(id -g)"
+  dry_run=0
 
   declare test no_teardown docker_user
-  while getopts hTkt:u: opt; do
+  while getopts hTkt:u:n opt; do
     case "${opt}" in
       T) test=1 ;;
       k) no_teardown=1 ;;
       t) tag="${OPTARG}" ;;
       u) docker_user="${OPTARG}" ;;
+      n) dry_run=1 ;;
       h) help && exit 0 ;;
       \?) >&2 help && exit 1 ;;
     esac
   done
   shift $((OPTIND - 1))
 
+  declare cmd
   declare -a docker_flags
   docker_flags=("-u" "${docker_user}")
 
@@ -78,14 +80,18 @@ main() {
       echo "Using existing network: ${TEST_NET}"
     else
       echo "Creating test network ${TEST_NET}"
-      docker network create "${TEST_NET}"
+      cmd="docker network create"
+      ((dry_run)) && cmd="echo ${cmd}"
+      ${cmd} "${TEST_NET}"
     fi
 
     if [[ "$(docker ps -a -q -f name=${TEST_SERVER_NAME})" ]]; then
       echo "Using existing test server container: ${TEST_SERVER_NAME}"
     else
       echo "Starting test server..."
-      docker run -d -q --name="${TEST_SERVER_NAME}" \
+      cmd="docker run"
+      ((dry_run)) && cmd="echo ${cmd}"
+      ${cmd} -d -q --name="${TEST_SERVER_NAME}" \
              --network="${TEST_NET}" \
              -v "${CWD}/${FIXTURES_DIR}":/usr/share/nginx/html \
              nginx:alpine
@@ -103,7 +109,7 @@ main() {
       exit
     fi
     echo "Cleaning up..."
-    {
+    ((dry_run)) || {
       docker container rm -f "${TEST_SERVER_NAME}"
       docker network rm -f "${TEST_NET}"
     } > /dev/null
@@ -153,7 +159,9 @@ docker_make() {
     -v "${CWD}/Makefile:${docker_workdir}/Makefile"
     -v "${CWD}/scripts:${docker_workdir}/scripts"
   )
-  docker run --rm "${docker_flags[@]}" "${image}:${tag}" make "$@"
+  cmd="docker run"
+  ((dry_run)) && cmd="echo ${cmd}"
+  ${cmd} --rm "${docker_flags[@]}" "${image}:${tag}" make "$@"
 }
 
 main "$@"

--- a/scripts/dockermake
+++ b/scripts/dockermake
@@ -36,20 +36,25 @@ main() {
   install_dir="${SWG_INSTALL_DIR:=hugo/static/data}"
   config_dir="${SWG_CONFIG_DIR:=config}"
 
-  declare -a docker_flags
+  declare test no_teardown
+  while getopts hTkt: opt; do
+    case "${opt}" in
+      T) test=1 ;;
+      k) no_teardown=1 ;;
+      t) tag="${OPTARG}" ;;
+      h) help && exit 0 ;;
+      \?) >&2 help && exit 1 ;;
+    esac
+  done
+  shift $((OPTIND - 1))
 
-  if [[ -n $SWG_UID || -n $SWG_GID ]];
+  declare -a docker_flags
+  if [[ -n ${SWG_UID} || -n ${SWG_GID} ]];
   then
     docker_flags+=("-u" "${SWG_UID:-$(id -u)}:${SWG_GID:-$(id -g)}")
   fi
 
-  if [[ "$1" == "--test" || "$1" == "-t" ]]; then
-    shift
-
-    if [[ "$1" == "--keep" || "$1" == "-k" ]]; then
-      _NO_TEARDOWN=1
-      shift
-    fi
+  if ((test)); then
 
     data_dir=tests/data
     install_dir=tests/public
@@ -80,7 +85,7 @@ main() {
     docker_flags+=(--network="$_TEST_NET")
     docker_make "$@"
 
-    if [[ $_NO_TEARDOWN == 1 ]]; then
+    if ((no_teardown)); then
       echo "Keeping test resources running"
       echo "To clean up manually:"
       echo "    docker container rm -f $_TEST_SERVER_NAME"

--- a/scripts/dockermake
+++ b/scripts/dockermake
@@ -40,85 +40,84 @@ declare -a docker_flags
 # Arguments:
 #   All passsed arguments are forwarded to `make`
 docker_make() {
-    local -r docker_workdir='/swedgene'
-    # Make sure writable directories exist on the host
-    mkdir -p "$SWG_DATA_DIR" "$SWG_INSTALL_DIR"
+  local -r docker_workdir='/swedgene'
+  # Make sure writable directories exist on the host
+  mkdir -p "$SWG_DATA_DIR" "$SWG_INSTALL_DIR"
 
-    # Build the docker argument list, specifying mount points and
-    # environment variables
-    for dir in SWG_DATA_DIR SWG_INSTALL_DIR SWG_CONFIG_DIR; do
-	# The ! in the parameter expansion introductes a level of
-	# indirection: the result is the value of the variable whose
-	# name is $dir
-	docker_flags+=(
-	    -v "$CWD/${!dir}:$docker_workdir/${!dir}"
-	    -e "$dir=${!dir}"
-	)
-    done
-    # Don't forget the Makefile and script directory
+  # Build the docker argument list, specifying mount points and
+  # environment variables
+  for dir in SWG_DATA_DIR SWG_INSTALL_DIR SWG_CONFIG_DIR; do
+    # The ! in the parameter expansion introductes a level of
+    # indirection: the result is the value of the variable whose
+    # name is $dir
     docker_flags+=(
-	-v "$CWD/Makefile:$docker_workdir/Makefile"
-	-v "$CWD/scripts:$docker_workdir/scripts"
+      -v "$CWD/${!dir}:$docker_workdir/${!dir}"
+      -e "$dir=${!dir}"
     )
-    docker run --rm "${docker_flags[@]}" "${SWG_IMAGE}:${SWG_TAG}" make "$@"
+  done
+  # Don't forget the Makefile and script directory
+  docker_flags+=(
+    -v "$CWD/Makefile:$docker_workdir/Makefile"
+    -v "$CWD/scripts:$docker_workdir/scripts"
+  )
+  docker run --rm "${docker_flags[@]}" "${SWG_IMAGE}:${SWG_TAG}" make "$@"
 }
 
 if [[ -n $SWG_UID || -n $SWG_GID ]];
 then
-    docker_flags+=("-u" "${SWG_UID:-$(id -u)}:${SWG_GID:-$(id -g)}")
+  docker_flags+=("-u" "${SWG_UID:-$(id -u)}:${SWG_GID:-$(id -g)}")
 fi
 
 if [[ "$1" == "--test" || "$1" == "-t" ]]; then
+  shift
+
+  if [[ "$1" == "--keep" || "$1" == "-k" ]]; then
+    _NO_TEARDOWN=1
     shift
+  fi
 
-    if [[ "$1" == "--keep" || "$1" == "-k" ]]; then
-	_NO_TEARDOWN=1
-	shift
-    fi
+  SWG_DATA_DIR=tests/data
+  SWG_INSTALL_DIR=tests/public
+  SWG_CONFIG_DIR=tests/config
+  SWG_FIXTURES_DIR=tests/fixtures
+  _TEST_NET=swg-test-net
+  _TEST_SERVER_NAME=fixtures
+  _WORKDIR=/swedgene
 
-    SWG_DATA_DIR=tests/data
-    SWG_INSTALL_DIR=tests/public
-    SWG_CONFIG_DIR=tests/config
-    SWG_FIXTURES_DIR=tests/fixtures
-    _TEST_NET=swg-test-net
-    _TEST_SERVER_NAME=fixtures
-    _WORKDIR=/swedgene
+  if [[ "$(docker network ls -q -f name=$_TEST_NET)" ]]; then
+    echo "Using existing network: $_TEST_NET"
+  else
+    echo "Creating test network $_TEST_NET"
+    docker network create $_TEST_NET
+  fi
 
-    if [[ "$(docker network ls -q -f name=$_TEST_NET)" ]]; then
-	echo "Using existing network: $_TEST_NET"
-    else
-	echo "Creating test network $_TEST_NET"
-	docker network create $_TEST_NET
-    fi
+  if [[ "${_CID:=$(docker ps -a -q -f name=$_TEST_SERVER_NAME)}" ]]; then
+    echo "Using existing test server container: ${_TEST_SERVER_NAME}"
+  else
+    echo "Starting test server..."
+    docker run -d -q --name=$_TEST_SERVER_NAME \
+           --network=$_TEST_NET \
+           -v "$CWD/$SWG_FIXTURES_DIR":/usr/share/nginx/html \
+           nginx:alpine
+  fi
 
-    if [[ "${_CID:=$(docker ps -a -q -f name=$_TEST_SERVER_NAME)}" ]]; then
-	echo "Using existing test server container: ${_TEST_SERVER_NAME}"
-    else
-	    echo "Starting test server..."
-	    docker run -d -q --name=$_TEST_SERVER_NAME \
-		   --network=$_TEST_NET \
-		   -v "$CWD/$SWG_FIXTURES_DIR":/usr/share/nginx/html \
-		   nginx:alpine
-    fi
+  # Run the test build
+  docker_flags+=(--network="$_TEST_NET")
+  docker_make "$@"
 
-    # Run the test build
-    docker_flags+=(--network="$_TEST_NET")
-    docker_make "$@"
-
-    if [[ $_NO_TEARDOWN == 1 ]]; then
-	echo "Keeping test resources running"
-	echo "To clean up manually:"
-	echo "    docker container rm -f $_TEST_SERVER_NAME"
-	echo "    docker network rm $_TEST_NET"
-	exit
-    fi
-    echo "Cleaning up..."
-    {
-	docker container rm -f $_TEST_SERVER_NAME
-	docker network rm -f $_TEST_NET
-    } > /dev/null
+  if [[ $_NO_TEARDOWN == 1 ]]; then
+    echo "Keeping test resources running"
+    echo "To clean up manually:"
+    echo "    docker container rm -f $_TEST_SERVER_NAME"
+    echo "    docker network rm $_TEST_NET"
+    exit
+  fi
+  echo "Cleaning up..."
+  {
+    docker container rm -f $_TEST_SERVER_NAME
+    docker network rm -f $_TEST_NET
+  } > /dev/null
 
 else
-    docker_make "$@"
+  docker_make "$@"
 fi
-

--- a/scripts/dockermake
+++ b/scripts/dockermake
@@ -56,46 +56,49 @@ main() {
 
   if ((test)); then
 
-    data_dir=tests/data
-    install_dir=tests/public
-    config_dir=tests/config
-    SWG_FIXTURES_DIR=tests/fixtures
-    _TEST_NET=swg-test-net
-    _TEST_SERVER_NAME=fixtures
-    _WORKDIR=/swedgene
+    TEST_DIR="${SWG_TEST_DIR:-tests}"
+    FIXTURES_DIR="${TEST_DIR}/fixtures"
+    TEST_NET=swg-test-net
+    TEST_SERVER_NAME=fixtures
+    readonly TEST_DIR FIXTURES_DIR TEST_NET TEST_SERVER_NAME
 
-    if [[ "$(docker network ls -q -f name=$_TEST_NET)" ]]; then
-      echo "Using existing network: $_TEST_NET"
+    data_dir="${TEST_DIR}/data"
+    install_dir="${TEST_DIR}/public"
+    config_dir="${TEST_DIR}/config"
+
+
+    if [[ "$(docker network ls -q -f name=${TEST_NET})" ]]; then
+      echo "Using existing network: ${TEST_NET}"
     else
-      echo "Creating test network $_TEST_NET"
-      docker network create $_TEST_NET
+      echo "Creating test network ${TEST_NET}"
+      docker network create "${TEST_NET}"
     fi
 
-    if [[ "${_CID:=$(docker ps -a -q -f name=$_TEST_SERVER_NAME)}" ]]; then
-      echo "Using existing test server container: ${_TEST_SERVER_NAME}"
+    if [[ "$(docker ps -a -q -f name=${TEST_SERVER_NAME})" ]]; then
+      echo "Using existing test server container: ${TEST_SERVER_NAME}"
     else
       echo "Starting test server..."
-      docker run -d -q --name=$_TEST_SERVER_NAME \
-             --network=$_TEST_NET \
-             -v "$CWD/$SWG_FIXTURES_DIR":/usr/share/nginx/html \
+      docker run -d -q --name="${TEST_SERVER_NAME}" \
+             --network="${TEST_NET}" \
+             -v "${CWD}/${FIXTURES_DIR}":/usr/share/nginx/html \
              nginx:alpine
     fi
 
     # Run the test build
-    docker_flags+=(--network="$_TEST_NET")
+    docker_flags+=(--network="${TEST_NET}")
     docker_make "$@"
 
     if ((no_teardown)); then
       echo "Keeping test resources running"
       echo "To clean up manually:"
-      echo "    docker container rm -f $_TEST_SERVER_NAME"
-      echo "    docker network rm $_TEST_NET"
+      echo "    docker container rm -f ${TEST_SERVER_NAME}"
+      echo "    docker network rm ${TEST_NET}"
       exit
     fi
     echo "Cleaning up..."
     {
-      docker container rm -f $_TEST_SERVER_NAME
-      docker network rm -f $_TEST_NET
+      docker container rm -f "${TEST_SERVER_NAME}"
+      docker network rm -f "${TEST_NET}"
     } > /dev/null
 
   else

--- a/scripts/dockermake
+++ b/scripts/dockermake
@@ -10,80 +10,80 @@
 # used to override the Docker image to use. For example:
 #
 # SWG_IMAGE=industrious-squirrel SWG_TAG=slim-buster scripts/dockerbuild.sh build
+main() {
+  CWD="$(pwd)"
+  readonly CWD
 
-CWD="$(pwd)"
-readonly CWD
+  : ${SWG_TAG="main"}
+  : ${SWG_IMAGE:="ghcr.io/scilifelabdatacentre/swg-data-builder"}
 
-: ${SWG_TAG="main"}
-: ${SWG_IMAGE:="ghcr.io/scilifelabdatacentre/swg-data-builder"}
+  # Directories on the host that are mounted in the container, and used
+  # by `make`. Paths must be *relative* to the repository root.
+  : ${SWG_DATA_DIR:="data"}
+  : ${SWG_INSTALL_DIR:="hugo/static/data"}
+  : ${SWG_CONFIG_DIR:="config"}
 
-# Directories on the host that are mounted in the container, and used
-# by `make`. Paths must be *relative* to the repository root.
-: ${SWG_DATA_DIR:="data"}
-: ${SWG_INSTALL_DIR:="hugo/static/data"}
-: ${SWG_CONFIG_DIR:="config"}
+  declare -a docker_flags
 
-declare -a docker_flags
+  if [[ -n $SWG_UID || -n $SWG_GID ]];
+  then
+    docker_flags+=("-u" "${SWG_UID:-$(id -u)}:${SWG_GID:-$(id -g)}")
+  fi
 
-if [[ -n $SWG_UID || -n $SWG_GID ]];
-then
-  docker_flags+=("-u" "${SWG_UID:-$(id -u)}:${SWG_GID:-$(id -g)}")
-fi
-
-if [[ "$1" == "--test" || "$1" == "-t" ]]; then
-  shift
-
-  if [[ "$1" == "--keep" || "$1" == "-k" ]]; then
-    _NO_TEARDOWN=1
+  if [[ "$1" == "--test" || "$1" == "-t" ]]; then
     shift
-  fi
 
-  SWG_DATA_DIR=tests/data
-  SWG_INSTALL_DIR=tests/public
-  SWG_CONFIG_DIR=tests/config
-  SWG_FIXTURES_DIR=tests/fixtures
-  _TEST_NET=swg-test-net
-  _TEST_SERVER_NAME=fixtures
-  _WORKDIR=/swedgene
+    if [[ "$1" == "--keep" || "$1" == "-k" ]]; then
+      _NO_TEARDOWN=1
+      shift
+    fi
 
-  if [[ "$(docker network ls -q -f name=$_TEST_NET)" ]]; then
-    echo "Using existing network: $_TEST_NET"
+    SWG_DATA_DIR=tests/data
+    SWG_INSTALL_DIR=tests/public
+    SWG_CONFIG_DIR=tests/config
+    SWG_FIXTURES_DIR=tests/fixtures
+    _TEST_NET=swg-test-net
+    _TEST_SERVER_NAME=fixtures
+    _WORKDIR=/swedgene
+
+    if [[ "$(docker network ls -q -f name=$_TEST_NET)" ]]; then
+      echo "Using existing network: $_TEST_NET"
+    else
+      echo "Creating test network $_TEST_NET"
+      docker network create $_TEST_NET
+    fi
+
+    if [[ "${_CID:=$(docker ps -a -q -f name=$_TEST_SERVER_NAME)}" ]]; then
+      echo "Using existing test server container: ${_TEST_SERVER_NAME}"
+    else
+      echo "Starting test server..."
+      docker run -d -q --name=$_TEST_SERVER_NAME \
+             --network=$_TEST_NET \
+             -v "$CWD/$SWG_FIXTURES_DIR":/usr/share/nginx/html \
+             nginx:alpine
+    fi
+
+    # Run the test build
+    docker_flags+=(--network="$_TEST_NET")
+    docker_make "$@"
+
+    if [[ $_NO_TEARDOWN == 1 ]]; then
+      echo "Keeping test resources running"
+      echo "To clean up manually:"
+      echo "    docker container rm -f $_TEST_SERVER_NAME"
+      echo "    docker network rm $_TEST_NET"
+      exit
+    fi
+    echo "Cleaning up..."
+    {
+      docker container rm -f $_TEST_SERVER_NAME
+      docker network rm -f $_TEST_NET
+    } > /dev/null
+
   else
-    echo "Creating test network $_TEST_NET"
-    docker network create $_TEST_NET
+    docker_make "$@"
   fi
-
-  if [[ "${_CID:=$(docker ps -a -q -f name=$_TEST_SERVER_NAME)}" ]]; then
-    echo "Using existing test server container: ${_TEST_SERVER_NAME}"
-  else
-    echo "Starting test server..."
-    docker run -d -q --name=$_TEST_SERVER_NAME \
-           --network=$_TEST_NET \
-           -v "$CWD/$SWG_FIXTURES_DIR":/usr/share/nginx/html \
-           nginx:alpine
-  fi
-
-  # Run the test build
-  docker_flags+=(--network="$_TEST_NET")
-  docker_make "$@"
-
-  if [[ $_NO_TEARDOWN == 1 ]]; then
-    echo "Keeping test resources running"
-    echo "To clean up manually:"
-    echo "    docker container rm -f $_TEST_SERVER_NAME"
-    echo "    docker network rm $_TEST_NET"
-    exit
-  fi
-  echo "Cleaning up..."
-  {
-    docker container rm -f $_TEST_SERVER_NAME
-    docker network rm -f $_TEST_NET
-  } > /dev/null
-
-else
-  docker_make "$@"
-fi
-
+}
 
 # Run make in Docker container
 #
@@ -123,4 +123,4 @@ docker_make() {
   docker run --rm "${docker_flags[@]}" "${SWG_IMAGE}:${SWG_TAG}" make "$@"
 }
 
-
+main "$@"

--- a/scripts/dockermake
+++ b/scripts/dockermake
@@ -2,21 +2,28 @@
 
 help() {
   echo "\
-Run 'make' in a Docker container
+Run 'make' in a Docker container, using our Makefile recipes.
 
-Usage: dockermake [options] [arg...]
+The Docker image used is
+'ghcr.io/scilifelabdatacentre/swg-data-builder:local', and an alternative
+tag can be chosen with the -t option.
 
-Non-option command line arguments are passed to 'make'.
+Usage: dockermake [-T] [-k] [-t TAG] [-u USER] [arg...]
 
-The environment variables SWG_UID and SWG_GID can be used to run the
-container as a specific user and group. By default, the effective user
-and group id of the host are used.
+Positional arguments are passed to 'make'
 
-The environment variables SWG_IMAGE and SWG_TAG can be used to
-override the Docker image to use. For example:
+Options:
+  -h            Display this help message and exit
+  -T            Use test configuration, found in SWG_TEST_DIR (default: tests)
+                Start a web server rooted at SWG_TEST_DIR/fixtures.
+  -k            Keep test resources running, no teardown is performed.
+                Useful for consecutive test runs.
+  -t  TAG       Docker tag to use for the data builder image
+  -u  USER      Docker user, specified as '<USER>:<GROUP>'.
+                Default: host user and group IDs, so that files
+                created in mounted directories have convenient ownership.
 
-export SWG_IMAGE=industrious-squirrel SWG_TAG=slim-buster
-scripts/dockerbuild.sh build
+
 "
 
 }

--- a/scripts/dockermake
+++ b/scripts/dockermake
@@ -25,44 +25,6 @@ readonly CWD
 
 declare -a docker_flags
 
-# Run make in Docker container
-#
-# Mount Makefile and directories to use for data, configuration and
-# installation
-#
-# Globals:
-#   SWG_DATA_DIR
-#   SWG_INSTALL_DIR
-#   SWG_CONFIG_DIR
-#   SWG_IMAGE
-#   SWG_TAG
-#   CWD
-# Arguments:
-#   All passsed arguments are forwarded to `make`
-docker_make() {
-  local -r docker_workdir='/swedgene'
-  # Make sure writable directories exist on the host
-  mkdir -p "$SWG_DATA_DIR" "$SWG_INSTALL_DIR"
-
-  # Build the docker argument list, specifying mount points and
-  # environment variables
-  for dir in SWG_DATA_DIR SWG_INSTALL_DIR SWG_CONFIG_DIR; do
-    # The ! in the parameter expansion introductes a level of
-    # indirection: the result is the value of the variable whose
-    # name is $dir
-    docker_flags+=(
-      -v "$CWD/${!dir}:$docker_workdir/${!dir}"
-      -e "$dir=${!dir}"
-    )
-  done
-  # Don't forget the Makefile and script directory
-  docker_flags+=(
-    -v "$CWD/Makefile:$docker_workdir/Makefile"
-    -v "$CWD/scripts:$docker_workdir/scripts"
-  )
-  docker run --rm "${docker_flags[@]}" "${SWG_IMAGE}:${SWG_TAG}" make "$@"
-}
-
 if [[ -n $SWG_UID || -n $SWG_GID ]];
 then
   docker_flags+=("-u" "${SWG_UID:-$(id -u)}:${SWG_GID:-$(id -g)}")
@@ -121,3 +83,44 @@ if [[ "$1" == "--test" || "$1" == "-t" ]]; then
 else
   docker_make "$@"
 fi
+
+
+# Run make in Docker container
+#
+# Mount Makefile and directories to use for data, configuration and
+# installation
+#
+# Globals:
+#   SWG_DATA_DIR
+#   SWG_INSTALL_DIR
+#   SWG_CONFIG_DIR
+#   SWG_IMAGE
+#   SWG_TAG
+#   CWD
+# Arguments:
+#   All passsed arguments are forwarded to `make`
+docker_make() {
+  local -r docker_workdir='/swedgene'
+  # Make sure writable directories exist on the host
+  mkdir -p "$SWG_DATA_DIR" "$SWG_INSTALL_DIR"
+
+  # Build the docker argument list, specifying mount points and
+  # environment variables
+  for dir in SWG_DATA_DIR SWG_INSTALL_DIR SWG_CONFIG_DIR; do
+    # The ! in the parameter expansion introductes a level of
+    # indirection: the result is the value of the variable whose
+    # name is $dir
+    docker_flags+=(
+      -v "$CWD/${!dir}:$docker_workdir/${!dir}"
+      -e "$dir=${!dir}"
+    )
+  done
+  # Don't forget the Makefile and script directory
+  docker_flags+=(
+    -v "$CWD/Makefile:$docker_workdir/Makefile"
+    -v "$CWD/scripts:$docker_workdir/scripts"
+  )
+  docker run --rm "${docker_flags[@]}" "${SWG_IMAGE}:${SWG_TAG}" make "$@"
+}
+
+

--- a/scripts/dockermake
+++ b/scripts/dockermake
@@ -22,11 +22,12 @@ scripts/dockerbuild.sh build
 }
 
 main() {
-  CWD="$(pwd)"
+  CWD="$(git rev-parse --show-toplevel)"
   readonly CWD
 
-  : ${SWG_TAG="main"}
-  : ${SWG_IMAGE:="ghcr.io/scilifelabdatacentre/swg-data-builder"}
+  declare tag image
+  tag="${SWG_TAG:-local}"
+  image="${SWG_IMAGE:-ghcr.io/scilifelabdatacentre/swg-data-builder}"
 
   # Directories on the host that are mounted in the container, and used
   # by `make`. Paths must be *relative* to the repository root.
@@ -131,7 +132,7 @@ docker_make() {
     -v "$CWD/Makefile:$docker_workdir/Makefile"
     -v "$CWD/scripts:$docker_workdir/scripts"
   )
-  docker run --rm "${docker_flags[@]}" "${SWG_IMAGE}:${SWG_TAG}" make "$@"
+  docker run --rm "${docker_flags[@]}" "${image}:${tag}" make "$@"
 }
 
 main "$@"

--- a/scripts/dockerserve
+++ b/scripts/dockerserve
@@ -1,8 +1,28 @@
 #!/bin/bash
 
-# Serve hugo site in a Docker container
-#
-# See usage function below
+help() {
+  echo "\
+Serve Genome Portal in a Docker container
+
+Usage: dockerserve [-h] [-t TAG] [-p PORT] [-d] [-n]
+
+Options:
+  -h            Display this help message and exit
+  -t TAG        Docker image tag. Default: local
+  -p PORT       Host port. Default: 8080
+  -d            Use Hugo development server (formerly --dev)
+  -n            Dry run
+
+Legacy SWG-prefixed environment variables are still supported
+(but command line counterparts take precedence). For example, to serve on
+port 8000 with the 'latest' tag, the following are equivalent:
+
+  SWG_PORT=8000 SWG_TAG=latest ./scripts/dockerserve
+
+  ./scripts/dockerserve -t latest -p 8000
+"
+}
+
 main() {
 
   local image="${SWG_IMAGE:-ghcr.io/scilifelabdatacentre/swg-hugo-site}" \
@@ -11,46 +31,37 @@ main() {
         datadir="${SWG_DATA_DIR:-data}" \
         hugo_image="${SWG_HUGO_IMAGE:=hugomods/hugo}" \
         hugo_tag="${SWG_HUGO_TAG:=std-base-0.138.0}" \
-        dev=false \
-        container_name=genome-portal
+        dev=0 \
+        container_name=genome-portal \
+        dry_run=0
 
-  while getopts i:t:p:dh opt; do
+  while getopts t:p:dhn opt; do
     case "${opt}" in
-      i)
-        image="${OPTARG}";;
-      t)
-        tag="${OPTARG}";;
-      p)
-        port="${OPTARG}";;
-      d)
-        dev=true;;
-      h)
-        usage
-        exit 0
-        ;;
-      \?)
-        usage
-        exit 1
-        ;;
+      t) tag="${OPTARG}" ;;
+      p) port="${OPTARG}" ;;
+      d) dev=1 ;;
+      h) help; exit 0 ;;
+      n) dry_run=1 ;;
+      \?) >&2 help; exit 1 ;;
     esac
   done
 
   if [[ -n "${cid:=$(docker ps -qaf name=${container_name})}" ]]; then
     cat <<-EOF
-Name '${container_name}' already taken by container ${cid}.
-To stop and remove:
-    docker rm -f ${cid}
+	Name '${container_name}' already taken by container ${cid}.
+	To stop and remove:
+	  docker rm -f ${cid}
 EOF
     return 1
   fi
 
-  if run >/dev/null 2>/tmp/dockerserve.log; then
+  if run 2>/tmp/dockerserve.log && ! ((dry_run)); then
     cat <<-EOF
-    - Web server is running in container "${container_name}".
-    - Site can be visited at http://localhost:${port}
+	- Web server is running in container "${container_name}".
+	- Site can be visited at http://localhost:${port}
 
-    To shut down:
-        docker rm -f "${container_name}"
+	To shut down:
+	  docker rm -f "${container_name}"
 EOF
   else
     cat /tmp/dockerserve.log
@@ -58,43 +69,25 @@ EOF
 }
 
 run() {
-  if [[ "${dev}" = true ]]; then
-    docker run --rm -d  \
+  run_cmd="docker run"
+  if ((dry_run)); then
+    run_cmd="echo ${run_cmd}"
+  fi
+
+  if ((dev)); then
+    ${run_cmd} --rm -d  \
            -p "${port}":1313 \
            -p 1313:1313 \
            -v "$(pwd)/hugo":"/src" \
            --name "${container_name}" \
            "${hugo_image}:${hugo_tag}" hugo server --bind 0.0.0.0
   else
-    docker run -d  \
+    ${run_cmd} -d  \
            -p "${port}":8080 \
            -v "$(pwd)/${datadir}":"/usr/share/nginx/html/data" \
            --name "${container_name}" \
            "${image}:${tag}"
   fi
-}
-
-usage() {
-  cat <<EOF
-dockerserve [-t TAG] [-i IMAGE] [-p PORT] [-d]
-
-Serve Genome Portal in a Docker container
-
-Customize the run using the options below, or the corresponding
-SWG-prefixed environment variables. For example, to serve on host port
-8000 with the image tagged 'latest', the following are equivalent:
-
-  SWG_PORT=8000 SWG_TAG=latest ./scripts/dockerserve
-
-  ./scripts/dockerserve -t latest -p 8000
-
-Options:
-  -d            Use Hugo development server
-  -i IMAGE      Docker image to use.
-                Default: ghcr.io/scilifelabdatacentre/swg-hugo-site
-  -p PORT       Host port. Default: 8080
-  -t TAG        Docker image tag. Default: local
-EOF
 }
 
 main "$@"

--- a/scripts/dockerserve
+++ b/scripts/dockerserve
@@ -1,18 +1,8 @@
 #!/bin/bash
-#
+
 # Serve hugo site in a Docker container
 #
-# Customize the run by setting the corresponding SWG-prefixed
-# environment variables, or by using command line options. For
-# example, to serve on host port 8000 with the image tagged `latest`,
-# the following are equivalent:
-#
-# SWG_PORT=8000 SWG_TAG=latest ./scripts/dockerserve
-#
-# ./scripts/dockerserve -t latest -p 8000
-#
-# With the -d option, run a hugo development server with a filesystem
-# mount. The -h options prints the list of available options.
+# See usage function below
 main() {
 
   local image="${SWG_IMAGE:-ghcr.io/scilifelabdatacentre/swg-hugo-site}" \
@@ -86,7 +76,24 @@ run() {
 
 usage() {
   cat <<EOF
-Usage: dockerserve [-t TAG] [-i IMAGE] [-p PORT] [-d]
+dockerserve [-t TAG] [-i IMAGE] [-p PORT] [-d]
+
+Serve Genome Portal in a Docker container
+
+Customize the run using the options below, or the corresponding
+SWG-prefixed environment variables. For example, to serve on host port
+8000 with the image tagged 'latest', the following are equivalent:
+
+  SWG_PORT=8000 SWG_TAG=latest ./scripts/dockerserve
+
+  ./scripts/dockerserve -t latest -p 8000
+
+Options:
+  -d            Use Hugo development server
+  -i IMAGE      Docker image to use.
+                Default: ghcr.io/scilifelabdatacentre/swg-hugo-site
+  -p PORT       Host port. Default: 8080
+  -t TAG        Docker image tag. Default: local
 EOF
 }
 

--- a/scripts/dockerserve
+++ b/scripts/dockerserve
@@ -15,81 +15,77 @@
 # mount. The -h options prints the list of available options.
 main() {
 
-    declare -A options=(
-	[image]="${SWG_IMAGE:-ghcr.io/scilifelabdatacentre/swg-hugo-site}"
-	[tag]="${SWG_TAG:-local}"
-	[port]="${SWG_PORT:-8080}"
-	[dev]=false
-    )
+  local image="${SWG_IMAGE:-ghcr.io/scilifelabdatacentre/swg-hugo-site}" \
+        tag="${SWG_TAG:-local}" \
+        port="${SWG_PORT:-8080}" \
+        datadir="${SWG_DATA_DIR:-data}" \
+        hugo_image="${SWG_HUGO_IMAGE:=hugomods/hugo}" \
+        hugo_tag="${SWG_HUGO_TAG:=std-base-0.138.0}" \
+        dev=false \
+        container_name=genome-portal
 
-    declare container_name=genome-portal \
-	    datadir="${SWG_DATA_DIR:-data}" \
-	    hugo_image="${SWG_HUGO_IMAGE:=hugomods/hugo}" \
-	    hugo_tag="${SWG_HUGO_TAG:=std-base-0.138.0}"
+  while getopts i:t:p:dh opt; do
+    case "${opt}" in
+      i)
+        image="${OPTARG}";;
+      t)
+        tag="${OPTARG}";;
+      p)
+        port="${OPTARG}";;
+      d)
+        dev=true;;
+      h)
+        usage
+        exit 0
+        ;;
+      \?)
+        usage
+        exit 1
+        ;;
+    esac
+  done
 
-    while getopts i:t:p:dh opt; do
-	case "${opt}" in
-	    i)
-		options[image]="${OPTARG}";;
-	    t)
-		options[tag]="${OPTARG}";;
-	    p)
-		options[port]="${OPTARG}";;
-	    d)
-		options[dev]=true;;
-	    h)
-		usage
-		exit 0
-		;;
-	    *)
-		echo "Invalid option: ${opt}"
-		usage
-		exit 1
-		;;
-	esac
-    done
-
-    if [[ -n "${cid:=$(docker ps -qaf name=${container_name})}" ]]; then
+  if [[ -n "${cid:=$(docker ps -qaf name=${container_name})}" ]]; then
     cat <<-EOF
 Name '${container_name}' already taken by container ${cid}.
 To stop and remove:
     docker rm -f ${cid}
 EOF
     return 1
-    fi
+  fi
 
-    if run >/dev/null 2>/tmp/dockerserve.log; then
-	cat <<-EOF
+  if run >/dev/null 2>/tmp/dockerserve.log; then
+    cat <<-EOF
     - Web server is running in container "${container_name}".
-    - Site can be visited at http://localhost:${options[port]}
+    - Site can be visited at http://localhost:${port}
 
     To shut down:
-	docker rm -f "${container_name}"
+        docker rm -f "${container_name}"
 EOF
-    else
-	cat /tmp/dockerserve.log
-    fi
+  else
+    cat /tmp/dockerserve.log
+  fi
 }
 
 run() {
-    if [[ "${options[dev]}" = true ]]; then
-	docker run --rm -d  \
-	       -p "${options[port]}":1313 \
-	       -p 1313:1313 \
-	       -v "$(pwd)/hugo":"/src" \
-	       --name "${container_name}" \
-	       "${hugo_image}:${hugo_tag}" hugo server --bind 0.0.0.0
-    else
-	docker run -d  \
-	       -p "${options[port]}":8080 \
-	       -v "$(pwd)/${datadir}":"/usr/share/nginx/html/data" \
-	       --name "${container_name}" \
-	       "${options[image]}:${options[tag]}"
-    fi
+  if [[ "${dev}" = true ]]; then
+    docker run --rm -d  \
+           -p "${port}":1313 \
+           -p 1313:1313 \
+           -v "$(pwd)/hugo":"/src" \
+           --name "${container_name}" \
+           "${hugo_image}:${hugo_tag}" hugo server --bind 0.0.0.0
+  else
+    docker run -d  \
+           -p "${port}":8080 \
+           -v "$(pwd)/${datadir}":"/usr/share/nginx/html/data" \
+           --name "${container_name}" \
+           "${image}:${tag}"
+  fi
 }
 
 usage() {
-    cat <<EOF
+  cat <<EOF
 Usage: dockerserve [-t TAG] [-i IMAGE] [-p PORT] [-d]
 EOF
 }

--- a/scripts/dockerserve
+++ b/scripts/dockerserve
@@ -3,49 +3,95 @@
 # Serve hugo site in a Docker container
 #
 # Customize the run by setting the corresponding SWG-prefixed
-# environment variables. For example, to serve on host port 8000 with
-# the image tagged `latest`:
+# environment variables, or by using command line options. For
+# example, to serve on host port 8000 with the image tagged `latest`,
+# the following are equivalent:
 #
-# SWG_PORT=8000 SWG_TAG=latest ./scripts/dockerserve.sh
+# SWG_PORT=8000 SWG_TAG=latest ./scripts/dockerserve
 #
-# With the --dev option, run a hugo development server.
+# ./scripts/dockerserve -t latest -p 8000
+#
+# With the -d option, run a hugo development server with a filesystem
+# mount. The -h options prints the list of available options.
+main() {
 
-: "${SWG_IMAGE:=ghcr.io/scilifelabdatacentre/swg-hugo-site}"
-: "${SWG_TAG:=dev}"
-: "${SWG_NAME:=genome-portal}"
-: "${SWG_DATA_DIR:=data}"
-: "${SWG_PORT:=8080}"
-: "${SWG_HUGO_IMAGE:=hugomods/hugo}"
-: "${SWG_HUGO_TAG:=std-base-0.138.0}"
+    declare -A options=(
+	[image]="${SWG_IMAGE:-ghcr.io/scilifelabdatacentre/swg-hugo-site}"
+	[tag]="${SWG_TAG:-local}"
+	[port]="${SWG_PORT:-8080}"
+	[dev]=false
+    )
 
-if [[ -n "${cid:=$(docker ps -qaf name=${SWG_NAME})}" ]]; then
-    cat <<EOF
-Name '${SWG_NAME}' already taken by container ${cid}.
-To remove:
+    declare container_name=genome-portal \
+	    datadir="${SWG_DATA_DIR:-data}" \
+	    hugo_image="${SWG_HUGO_IMAGE:=hugomods/hugo}" \
+	    hugo_tag="${SWG_HUGO_TAG:=std-base-0.138.0}"
+
+    while getopts i:t:p:dh opt; do
+	case "${opt}" in
+	    i)
+		options[image]="${OPTARG}";;
+	    t)
+		options[tag]="${OPTARG}";;
+	    p)
+		options[port]="${OPTARG}";;
+	    d)
+		options[dev]=true;;
+	    h)
+		usage
+		exit 0
+		;;
+	    *)
+		echo "Invalid option: ${opt}"
+		usage
+		exit 1
+		;;
+	esac
+    done
+
+    if [[ -n "${cid:=$(docker ps -qaf name=${container_name})}" ]]; then
+    cat <<-EOF
+Name '${container_name}' already taken by container ${cid}.
+To stop and remove:
     docker rm -f ${cid}
 EOF
-    exit 1
-fi
+    return 1
+    fi
 
-if [[ "$1" == "--dev" ]]; then
-    SWG_NAME+="-dev"
-    docker run --rm -d  \
-	   -p "${SWG_PORT}":1313 \
-	   -p 1313:1313 \
-	   -v "$(pwd)/hugo":"/src" \
-	   --name "${SWG_NAME}" \
-	   "${SWG_HUGO_IMAGE}:${SWG_HUGO_TAG}" hugo server --bind 0.0.0.0
-else
-    docker run -d  \
-	   -p "${SWG_PORT}":8080 \
-	   -v "$(pwd)/${SWG_DATA_DIR}":"/usr/share/nginx/html/data" \
-	   --name "${SWG_NAME}" \
-	   "${SWG_IMAGE}:${SWG_TAG}"
-fi >/dev/null 2>/tmp/dockerserve.log && \
-    cat <<EOF || cat /tmp/dockerserve.log
-- Web server is running in container "${SWG_NAME}".
-- Site can be visited at http://localhost:${SWG_PORT}
+    if run >/dev/null 2>/tmp/dockerserve.log; then
+	cat <<-EOF
+    - Web server is running in container "${container_name}".
+    - Site can be visited at http://localhost:${options[port]}
 
-To shut down:
-    docker rm -f "${SWG_NAME}"
+    To shut down:
+	docker rm -f "${container_name}"
 EOF
+    else
+	cat /tmp/dockerserve.log
+    fi
+}
+
+run() {
+    if [[ "${options[dev]}" = true ]]; then
+	docker run --rm -d  \
+	       -p "${options[port]}":1313 \
+	       -p 1313:1313 \
+	       -v "$(pwd)/hugo":"/src" \
+	       --name "${container_name}" \
+	       "${hugo_image}:${hugo_tag}" hugo server --bind 0.0.0.0
+    else
+	docker run -d  \
+	       -p "${options[port]}":8080 \
+	       -v "$(pwd)/${datadir}":"/usr/share/nginx/html/data" \
+	       --name "${container_name}" \
+	       "${options[image]}:${options[tag]}"
+    fi
+}
+
+usage() {
+    cat <<EOF
+Usage: dockerserve [-t TAG] [-i IMAGE] [-p PORT] [-d]
+EOF
+}
+
+main "$@"

--- a/scripts/dockerserve
+++ b/scripts/dockerserve
@@ -70,9 +70,7 @@ EOF
 
 run() {
   run_cmd="docker run"
-  if ((dry_run)); then
-    run_cmd="echo ${run_cmd}"
-  fi
+  ((dry_run)) && run_cmd="echo ${run_cmd}"
 
   if ((dev)); then
     ${run_cmd} --rm -d  \

--- a/tests/bats/aliases.bats
+++ b/tests/bats/aliases.bats
@@ -1,14 +1,3 @@
-setup_file() {
-    bats_require_minimum_version 1.5.0
-    # Set BATS_LIB_PATH environment variable when invoking bats
-    # Example: export BATS_LIB_PATH=/my/custom/lib/; bats tests/bats
-    BATS_LIB_PATH="${BATS_LIB_PATH}":~/.local/lib:/usr/lib/bats
-
-    # Put our script directory in the executable search path
-    DIR="${BATS_TEST_DIRNAME}"/../../scripts
-    PATH="${DIR}:${PATH}"
-}
-
 setup() {
     bats_load_library 'bats-support'
     bats_load_library 'bats-assert'

--- a/tests/bats/dockerbuild.bats
+++ b/tests/bats/dockerbuild.bats
@@ -1,0 +1,14 @@
+setup() {
+    bats_load_library 'bats-support'
+    bats_load_library 'bats-assert'
+}
+
+@test "Build data builder image" {
+  run dockerbuild -n -k data
+  assert_output --partial "-t ghcr.io/scilifelabdatacentre/swg-data-builder:local -f docker/data.dockerfile"
+}
+
+@test "Build hugo site image" {
+  run dockerbuild -n -k hugo
+  assert_output --partial "-t ghcr.io/scilifelabdatacentre/swg-hugo-site:local -f docker/hugo.dockerfile"
+}

--- a/tests/bats/dockermake.bats
+++ b/tests/bats/dockermake.bats
@@ -1,0 +1,17 @@
+setup() {
+    bats_load_library 'bats-support'
+    bats_load_library 'bats-assert'
+}
+
+@test "Run make" {
+  run dockermake -n debug
+  assert_output --partial "ghcr.io/scilifelabdatacentre/swg-data-builder:local make debug"
+}
+
+@test "Run make in with test configuration" {
+  run dockermake -n -T debug
+  assert_output --partial "ghcr.io/scilifelabdatacentre/swg-data-builder:local make debug"
+  assert_output --partial "docker network create swg-test-net"
+  assert_output --regexp "docker run -d .* --network=swg-test-net .* nginx:alpine"
+}
+

--- a/tests/bats/dockerserve.bats
+++ b/tests/bats/dockerserve.bats
@@ -1,0 +1,15 @@
+setup() {
+    bats_load_library 'bats-support'
+    bats_load_library 'bats-assert'
+}
+
+@test "Runs Hugo development server" {
+  run dockerserve -n -d
+  assert_output --partial "hugo server"
+}
+
+@test "Run genome portal image" {
+  run dockerserve -n
+  assert_output --partial "docker run -d"
+  assert_output --partial "ghcr.io/scilifelabdatacentre/swg-hugo-site:local"
+}

--- a/tests/bats/generate_jbrowse_config.bats
+++ b/tests/bats/generate_jbrowse_config.bats
@@ -1,14 +1,3 @@
-setup_file() {
-    bats_require_minimum_version 1.5.0
-    # Set BATS_LIB_PATH environment variable when invoking bats
-    # Example: export BATS_LIB_PATH=/my/custom/lib/; bats tests/bats
-    BATS_LIB_PATH="${BATS_LIB_PATH}":~/.local/lib:/usr/lib/bats
-
-    # Put our script directory in the executable search path
-    DIR="${BATS_TEST_DIRNAME}"/../../scripts
-    PATH="${DIR}:${PATH}"
-}
-
 setup() {
     bats_load_library 'bats-support'
     bats_load_library 'bats-assert'

--- a/tests/bats/setup_suite.bash
+++ b/tests/bats/setup_suite.bash
@@ -1,0 +1,10 @@
+setup_suite() {
+    bats_require_minimum_version 1.5.0
+    # Set BATS_LIB_PATH environment variable when invoking bats
+    # Example: export BATS_LIB_PATH=/my/custom/lib/; bats tests/bats
+    BATS_LIB_PATH="${BATS_LIB_PATH}":~/.local/lib:/usr/lib/bats
+
+    # Put our script directory in the executable search path
+    DIR="${BATS_TEST_DIRNAME}"/../../scripts
+    PATH="${DIR}:${PATH}"
+}


### PR DESCRIPTION
Introduces a more convenient CLI interface to `dockerserve`, `dockerbuild` and `dockermake`, using command line options rather than `SWG_` prefixed environment variables. For example our beloved idiom:
```
SWG_TAG=local ./scripts/dockerserve
```
becomes:
```
./scripts/dockerserve -t local
```
or even, since `local` is now the default tag:
```
./scripts/dockerserve -t local
```

Another significant change: the  `--dev` option to `dockerseve` becomes `-d`.

`SWG` environment variables are still supported for ~nostalgia~ backwards compatibility.

A comprehensive description of the new CLI is displayed by `./scripts/dockerserve -h` and `./scripts/dockerbuild -h` 😎 