### PR TITLE
bugfix(make): Install generated aliases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,8 @@ BED_INDICES := $(addsuffix .tbi,$(BED))
 LOCAL_FILES := $(GFF) $(GFF_INDICES) \
 	$(FASTA) $(FASTA_INDICES) $(FASTA_GZINDICES) \
 	$(GTF) \
-	$(BED) $(BED_INDICES)
+	$(BED) $(BED_INDICES) \
+	$(ALIASES)
 
 # Files to install
 INSTALLED_FILES := $(patsubst $(DATA_DIR)/%,$(INSTALL_DIR)/%, $(LOCAL_FILES) $(JBROWSE_CONFIGS))


### PR DESCRIPTION
Add all generated `aliases.txt` to the list of files copied by `make install` to the installation directory. In other words, the web server will be able to access alias files after `make install` is run.
 