### PR TITLE
Update license with year and group

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 SciLifeLab
+Copyright (c) 2025 SciLifeLab Data Centre
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
As the title explains, this is for updating the repository license file based on the recent internal instructions at DC. Since we already used the MIT license, for us this was just a matter of changing the year to the "most recent year the software was updated (at least one commit)", and adding _Data Centre_ after SciLifeLab.

We also have the option to add a separate CC BY 4.0 license for the website content in addition to the MIT content. In practice, this would be done with a `LICENSE.md` such as in [this example](https://github.com/LibraryCarpentry/carpentries.org/blob/main/LICENSE.md). For now, I think the updated MIT license is sufficient, but I would be happy to look into how CC BY 4.0 would apply to the portal content. What are your thoughts?