### PR TITLE
EB-450: Use unique tags for each image build

### DIFF
--- a/.github/workflows/publish_images.yml
+++ b/.github/workflows/publish_images.yml
@@ -16,9 +16,8 @@ on:
   workflow_dispatch:
     inputs:
       docker_tag:
-        description: 'Docker tag for the image, default is dev. Use prod for a release branch fix'
+        description: 'Docker tag for the image, if left blank tag will be: dev-[commit hash]'
         required: false
-        default: 'dev'
 
 jobs:
   push-to-container-registry:
@@ -55,6 +54,8 @@ jobs:
         id: set-tag
         run: |
           ./set_docker_tag ${{ github.event_name }} \
+                           ${{ github.ref_name }} \
+                           ${{ github.sha }} \
                            ${{ github.event.inputs.docker_tag }} \
                            >> $GITHUB_OUTPUT
 

--- a/.github/workflows/publish_images.yml
+++ b/.github/workflows/publish_images.yml
@@ -65,7 +65,9 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           context: .
           file: ./docker/${{ matrix.dockerfile }}
-          tags: ghcr.io/scilifelabdatacentre/${{ matrix.image_name }}:${{ steps.set-tag.outputs.tag }}
+          tags: |
+            ghcr.io/scilifelabdatacentre/${{ matrix.image_name }}:${{ steps.set-tag.outputs.tag }}
+            ghcr.io/scilifelabdatacentre/${{ matrix.image_name }}:latest
           build-args: |
             HUGO_GIT_REF_NAME=${{ github.ref_name }}
             HUGO_GIT_SHA=${{ github.sha }}            

--- a/scripts/ci/set_docker_tag
+++ b/scripts/ci/set_docker_tag
@@ -7,11 +7,10 @@ REF_NAME=$2
 SHA=$3
 DOCKER_TAG=$4
 
-if [ -n "$DOCKER_TAG" ]; then
-   tag="$DOCKER_TAG"
-elif [ "$EVENT_NAME" = "release" ]; then
+
+if [ "$EVENT_NAME" = "release" ]; then
     tag="$REF_NAME"
 else
-    tag="dev-$SHA"
+    tag="${DOCKER_TAG:-$SHA}"
 fi
 echo "tag=$tag"

--- a/scripts/ci/set_docker_tag
+++ b/scripts/ci/set_docker_tag
@@ -1,8 +1,17 @@
 #!/bin/sh
-case "$1" in
-    release)
-        tag=prod;;
-    workflow_dispatch)
-        tag="$2";;
-esac
-echo "tag=${tag:-dev}"
+# Note: using getopts here could be a awkward as DOCKER_TAG sometimes exists, sometimes doesn't.
+# DOCKER_TAG occurs if triggered by workflow_dispatch and tag added.
+
+EVENT_NAME=$1
+REF_NAME=$2
+SHA=$3
+DOCKER_TAG=$4
+
+if [ -n "$DOCKER_TAG" ]; then
+   tag="$DOCKER_TAG"
+elif [ "$EVENT_NAME" = "release" ]; then
+    tag="$REF_NAME"
+else
+    tag="dev-$SHA"
+fi
+echo "tag=$tag"

--- a/tests/bats/set_docker_tag.bats
+++ b/tests/bats/set_docker_tag.bats
@@ -7,11 +7,10 @@ set_docker_tag="${BATS_TEST_DIRNAME}"/../../scripts/ci/set_docker_tag
     [ "$(${set_docker_tag} workflow_dispatch main 25e47f1814c742b4c61d326a63384d8dace869e2 foo)" = "tag=foo" ]
 }
 
-
 @test "Workflow dispatch without custom tag" {
-    [ "$(${set_docker_tag} workflow_dispatch main 25e47f1814c742b4c61d326a63384d8dace869e2)" = "tag=dev-25e47f1814c742b4c61d326a63384d8dace869e2" ]
+    [ "$(${set_docker_tag} workflow_dispatch main 25e47f1814c742b4c61d326a63384d8dace869e2)" = "tag=25e47f1814c742b4c61d326a63384d8dace869e2" ]
 }
 
 @test "Push" {
-    [ "$(${set_docker_tag} push main 25e47f1814c742b4c61d326a63384d8dace869e2)" = "tag=dev-25e47f1814c742b4c61d326a63384d8dace869e2" ]
+    [ "$(${set_docker_tag} push main 25e47f1814c742b4c61d326a63384d8dace869e2)" = "tag=25e47f1814c742b4c61d326a63384d8dace869e2" ]
 }

--- a/tests/bats/set_docker_tag.bats
+++ b/tests/bats/set_docker_tag.bats
@@ -1,12 +1,17 @@
 set_docker_tag="${BATS_TEST_DIRNAME}"/../../scripts/ci/set_docker_tag
 @test "Release" {
-    [ "$(${set_docker_tag} release)" = "tag=prod" ]
+    [ "$(${set_docker_tag} release v1.2.3 25e47f1814c742b4c61d326a63384d8dace869e2)" = "tag=v1.2.3" ]
 }
 
-@test "Workflow dispatch" {
-    [ "$(${set_docker_tag} workflow_dispatch foo)" = "tag=foo" ]
+@test "Workflow dispatch with custom tag" {
+    [ "$(${set_docker_tag} workflow_dispatch main 25e47f1814c742b4c61d326a63384d8dace869e2 foo)" = "tag=foo" ]
+}
+
+
+@test "Workflow dispatch without custom tag" {
+    [ "$(${set_docker_tag} workflow_dispatch main 25e47f1814c742b4c61d326a63384d8dace869e2)" = "tag=dev-25e47f1814c742b4c61d326a63384d8dace869e2" ]
 }
 
 @test "Push" {
-    [ "$(${set_docker_tag} push)" = "tag=dev" ]
+    [ "$(${set_docker_tag} push main 25e47f1814c742b4c61d326a63384d8dace869e2)" = "tag=dev-25e47f1814c742b4c61d326a63384d8dace869e2" ]
 }


### PR DESCRIPTION
This is the first step in the work towards being able to use ArgoCD to update deployments.

- releases are tagged like: v1.2.3
- workflow_dispatch tagged as either (1) custom user input or (2, if no input provided) dev-[commit sha] 
- Push to main tagged as dev-[commit sha]

Next steps:
- Update Kube-swedgene repo to use these image tags (create a new PR which can be merged once this is merged)
- Add genome-portal to ArgoCD instance 

With this setup, order of operations would be 
1.     images built by GH actions
2.    kube-swedgene repo manually updated (update tag in kustomize file, commit and push
3.    sync with ArgoCD.  

Optional addition, could be to automate step 2, either by having the GH actions run make the commit to update the tags for us or trying to use something like https://argocd-image-updater.readthedocs.io/en/stable/ - but that is for after we have the basic ArgoCD setup I think. 
