### PR TITLE
Switch to CSI indices for BED and GFF

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -178,7 +178,7 @@ define make_index
 	@$(SHELL) scripts/index $<
 endef
 
-$(GFF_INDICES) $(BED_INDICES): %.tbi: %
+$(GFF_INDICES) $(BED_INDICES): %.csi: %
 	$(make_index)
 
 $(FASTA_INDICES): %.fai: %

--- a/Makefile
+++ b/Makefile
@@ -50,14 +50,14 @@ ALIASES := $(addsuffix aliases.txt,$(sort $(dir $(FASTA))))
 
 # GFF files and indices
 GFF := $(addsuffix .bgz, $(filter %.gff,$(unzipped)))
-GFF_INDICES := $(addsuffix .tbi,$(GFF))
+GFF_INDICES := $(addsuffix .csi,$(GFF))
 
 # GTF files
 GTF := $(filter %.gtf,$(unzipped))
 
 # BED files
 BED := $(addsuffix .bgz,$(filter %.bed,$(unzipped)))
-BED_INDICES := $(addsuffix .tbi,$(BED))
+BED_INDICES := $(addsuffix .csi,$(BED))
 
 LOCAL_FILES := $(GFF) $(GFF_INDICES) \
 	$(FASTA) $(FASTA_INDICES) $(FASTA_GZINDICES) \

--- a/config/linum_tenue/config.json
+++ b/config/linum_tenue/config.json
@@ -327,8 +327,10 @@
           },
           "index": {
             "location": {
-              "uri": "Lten_pop06_TD.bed.bgz.tbi"
-            }
+              "uri": "Lten_pop06_TD.bed.bgz.csi",
+              "locationType": "UriLocation"
+            },
+            "indexType": "CSI"
           }
         },
         "displays": [
@@ -352,8 +354,10 @@
           },
           "index": {
             "location": {
-              "uri": "Lten_pop08_TD.bed.bgz.tbi"
-            }
+              "uri": "Lten_pop08_TD.bed.bgz.csi",
+              "locationType": "UriLocation"
+            },
+            "indexType": "CSI"
           }
         },
         "displays": [
@@ -377,8 +381,10 @@
           },
           "index": {
             "location": {
-              "uri": "Lten_pop17_TD.bed.bgz.tbi"
-            }
+              "uri": "Lten_pop17_TD.bed.bgz.csi",
+              "locationType": "UriLocation"
+            },
+            "indexType": "CSI"
           }
         },
         "displays": [
@@ -402,8 +408,10 @@
           },
           "index": {
             "location": {
-              "uri": "Lten_pop21_TD.bed.bgz.tbi"
-            }
+              "uri": "Lten_pop21_TD.bed.bgz.csi",
+              "locationType": "UriLocation"
+            },
+            "indexType": "CSI"
           }
         },
         "displays": [
@@ -427,8 +435,10 @@
           },
           "index": {
             "location": {
-              "uri": "Lten_pop23_TD.bed.bgz.tbi"
-            }
+              "uri": "Lten_pop23_TD.bed.bgz.csi",
+              "locationType": "UriLocation"
+            },
+            "indexType": "CSI"
           }
         },
         "displays": [
@@ -452,8 +462,10 @@
           },
           "index": {
             "location": {
-              "uri": "Lten_pop26_TD.bed.bgz.tbi"
-            }
+              "uri": "Lten_pop26_TD.bed.bgz.csi",
+              "locationType": "UriLocation"
+            },
+            "indexType": "CSI"
           }
         },
         "displays": [
@@ -477,8 +489,10 @@
           },
           "index": {
             "location": {
-              "uri": "Lten_pop32_TD.bed.bgz.tbi"
-            }
+              "uri": "Lten_pop32_TD.bed.bgz.csi",
+              "locationType": "UriLocation"
+            },
+            "indexType": "CSI"
           }
         },
         "displays": [
@@ -502,8 +516,10 @@
           },
           "index": {
             "location": {
-              "uri": "Lten_pop34_TD.bed.bgz.tbi"
-            }
+              "uri": "Lten_pop34_TD.bed.bgz.csi",
+              "locationType": "UriLocation"
+            },
+            "indexType": "CSI"
           }
         },
         "displays": [
@@ -527,8 +543,10 @@
           },
           "index": {
             "location": {
-              "uri": "Lten_pop06_Pi.bed.bgz.tbi"
-            }
+              "uri": "Lten_pop06_Pi.bed.bgz.csi",
+              "locationType": "UriLocation"
+            },
+            "indexType": "CSI"
           }
         },
         "displays": [
@@ -552,8 +570,10 @@
           },
           "index": {
             "location": {
-              "uri": "Lten_pop08_Pi.bed.bgz.tbi"
-            }
+              "uri": "Lten_pop08_Pi.bed.bgz.csi",
+              "locationType": "UriLocation"
+            },
+            "indexType": "CSI"
           }
         },
         "displays": [
@@ -577,8 +597,10 @@
           },
           "index": {
             "location": {
-              "uri": "Lten_pop17_Pi.bed.bgz.tbi"
-            }
+              "uri": "Lten_pop17_Pi.bed.bgz.csi",
+              "locationType": "UriLocation"
+            },
+            "indexType": "CSI"
           }
         },
         "displays": [
@@ -602,8 +624,10 @@
           },
           "index": {
             "location": {
-              "uri": "Lten_pop21_Pi.bed.bgz.tbi"
-            }
+              "uri": "Lten_pop21_Pi.bed.bgz.csi",
+              "locationType": "UriLocation"
+            },
+            "indexType": "CSI"
           }
         },
         "displays": [
@@ -627,8 +651,10 @@
           },
           "index": {
             "location": {
-              "uri": "Lten_pop23_Pi.bed.bgz.tbi"
-            }
+              "uri": "Lten_pop23_Pi.bed.bgz.csi",
+              "locationType": "UriLocation"
+            },
+            "indexType": "CSI"
           }
         },
         "displays": [
@@ -652,8 +678,10 @@
           },
           "index": {
             "location": {
-              "uri": "Lten_pop26_Pi.bed.bgz.tbi"
-            }
+              "uri": "Lten_pop26_Pi.bed.bgz.csi",
+              "locationType": "UriLocation"
+            },
+            "indexType": "CSI"
           }
         },
         "displays": [
@@ -677,8 +705,10 @@
           },
           "index": {
             "location": {
-              "uri": "Lten_pop32_Pi.bed.bgz.tbi"
-            }
+              "uri": "Lten_pop32_Pi.bed.bgz.csi",
+              "locationType": "UriLocation"
+            },
+            "indexType": "CSI"
           }
         },
         "displays": [
@@ -702,8 +732,10 @@
           },
           "index": {
             "location": {
-              "uri": "Lten_pop34_Pi.bed.bgz.tbi"
-            }
+              "uri": "Lten_pop34_Pi.bed.bgz.csi",
+              "locationType": "UriLocation"
+            },
+            "indexType": "CSI"
           }
         },
         "displays": [

--- a/config/linum_trigynum/config.json
+++ b/config/linum_trigynum/config.json
@@ -321,8 +321,10 @@
         },
         "index": {
           "location": {
-            "uri": "Ltri_pop01_TD.bed.bgz.tbi"
-          }
+            "uri": "Ltri_pop01_TD.bed.bgz.csi",
+            "locationType": "UriLocation"
+          },
+          "indexType": "CSI"
         }
       },
       "displays": [
@@ -346,8 +348,10 @@
         },
         "index": {
           "location": {
-            "uri": "Ltri_pop03_TD.bed.bgz.tbi"
-          }
+            "uri": "Ltri_pop03_TD.bed.bgz.csi",
+            "locationType": "UriLocation"
+          },
+          "indexType": "CSI"
         }
       },
       "displays": [
@@ -371,8 +375,10 @@
         },
         "index": {
           "location": {
-            "uri": "Ltri_pop04_TD.bed.bgz.tbi"
-          }
+            "uri": "Ltri_pop04_TD.bed.bgz.csi",
+            "locationType": "UriLocation"
+          },
+          "indexType": "CSI"
         }
       },
       "displays": [
@@ -396,8 +402,10 @@
         },
         "index": {
           "location": {
-            "uri": "Ltri_pop06_TD.bed.bgz.tbi"
-          }
+            "uri": "Ltri_pop06_TD.bed.bgz.csi",
+            "locationType": "UriLocation"
+          },
+          "indexType": "CSI"
         }
       },
       "displays": [
@@ -421,8 +429,10 @@
         },
         "index": {
           "location": {
-            "uri": "Ltri_pop07_TD.bed.bgz.tbi"
-          }
+            "uri": "Ltri_pop07_TD.bed.bgz.csi",
+            "locationType": "UriLocation"
+          },
+          "indexType": "CSI"
         }
       },
       "displays": [
@@ -446,8 +456,10 @@
         },
         "index": {
           "location": {
-            "uri": "Ltri_pop08_TD.bed.bgz.tbi"
-          }
+            "uri": "Ltri_pop08_TD.bed.bgz.csi",
+            "locationType": "UriLocation"
+          },
+          "indexType": "CSI"
         }
       },
       "displays": [
@@ -471,8 +483,10 @@
         },
         "index": {
           "location": {
-            "uri": "Ltri_pop10_TD.bed.bgz.tbi"
-          }
+            "uri": "Ltri_pop10_TD.bed.bgz.csi",
+            "locationType": "UriLocation"
+          },
+          "indexType": "CSI"
         }
       },
       "displays": [
@@ -496,8 +510,10 @@
         },
         "index": {
           "location": {
-            "uri": "Ltri_pop11_TD.bed.bgz.tbi"
-          }
+            "uri": "Ltri_pop11_TD.bed.bgz.csi",
+            "locationType": "UriLocation"
+          },
+          "indexType": "CSI"
         }
       },
       "displays": [
@@ -521,8 +537,10 @@
         },
         "index": {
           "location": {
-            "uri": "Ltri_pop01_Pi.bed.bgz.tbi"
-          }
+            "uri": "Ltri_pop01_Pi.bed.bgz.csi",
+            "locationType": "UriLocation"
+          },
+          "indexType": "CSI"
         }
       },
       "displays": [
@@ -546,8 +564,10 @@
         },
         "index": {
           "location": {
-            "uri": "Ltri_pop03_Pi.bed.bgz.tbi"
-          }
+            "uri": "Ltri_pop03_Pi.bed.bgz.csi",
+            "locationType": "UriLocation"
+          },
+          "indexType": "CSI"
         }
       },
       "displays": [
@@ -571,8 +591,10 @@
         },
         "index": {
           "location": {
-            "uri": "Ltri_pop04_Pi.bed.bgz.tbi"
-          }
+            "uri": "Ltri_pop04_Pi.bed.bgz.csi",
+            "locationType": "UriLocation"
+          },
+          "indexType": "CSI"
         }
       },
       "displays": [
@@ -596,8 +618,10 @@
         },
         "index": {
           "location": {
-            "uri": "Ltri_pop06_Pi.bed.bgz.tbi"
-          }
+            "uri": "Ltri_pop06_Pi.bed.bgz.csi",
+            "locationType": "UriLocation"
+          },
+          "indexType": "CSI"
         }
       },
       "displays": [
@@ -621,8 +645,10 @@
         },
         "index": {
           "location": {
-            "uri": "Ltri_pop07_Pi.bed.bgz.tbi"
-          }
+            "uri": "Ltri_pop07_Pi.bed.bgz.csi",
+            "locationType": "UriLocation"
+          },
+          "indexType": "CSI"
         }
       },
       "displays": [
@@ -646,8 +672,10 @@
         },
         "index": {
           "location": {
-            "uri": "Ltri_pop08_Pi.bed.bgz.tbi"
-          }
+            "uri": "Ltri_pop08_Pi.bed.bgz.csi",
+            "locationType": "UriLocation"
+          },
+          "indexType": "CSI"
         }
       },
       "displays": [
@@ -671,8 +699,10 @@
         },
         "index": {
           "location": {
-            "uri": "Ltri_pop10_Pi.bed.bgz.tbi"
-          }
+            "uri": "Ltri_pop10_Pi.bed.bgz.csi",
+            "locationType": "UriLocation"
+          },
+          "indexType": "CSI"
         }
       },
       "displays": [
@@ -696,8 +726,10 @@
         },
         "index": {
           "location": {
-            "uri": "Ltri_pop11_Pi.bed.bgz.tbi"
-          }
+            "uri": "Ltri_pop11_Pi.bed.bgz.csi",
+            "locationType": "UriLocation"
+          },
+          "indexType": "CSI"
         }
       },
       "displays": [

--- a/scripts/generate_jbrowse_config
+++ b/scripts/generate_jbrowse_config
@@ -45,7 +45,12 @@ ensure_local() {
     args_ref=(--load=inPlace)
     case "${local_file}" in
 	*.fna.bgz)
-	    args_ref+=(--type=bgzipFasta);;
+	  args_ref+=(--type=bgzipFasta);;
+        # Explicitly point to the index for bed/gff files
+        *.bed.bgz)
+          args_ref+=(--indexFile="${local_file}.csi");;
+        *.gff.bgz)
+          args_ref+=(--indexFile="${local_file}.csi");;
     esac
     args_ref+=("$local_file")
 }

--- a/scripts/index
+++ b/scripts/index
@@ -15,9 +15,9 @@ main() {
     echo "Indexing $1" >&2
     case "${1##*/}" in
 	*.gff.bgz)
-	    cmd=(tabix -p gff);;
+	    cmd=(tabix -p gff --csi);;
 	*.bed.bgz)
-	    cmd=(tabix -p bed);;
+	    cmd=(tabix -p bed --csi);;
 	*.fna.bgz)
 	    cmd=(samtools faidx);;
 	*)


### PR DESCRIPTION
CSI indices accomodate arbitrarily long chromosomes. Unlike TBI that was inadequate for the spruce, for example. This is an attempt to use CSI indices by default for all BED and GFF files.