### PR TITLE
EB-502: Enable iframing of genome-portal for plant-genie

### DIFF
--- a/docker/nginx-custom.conf
+++ b/docker/nginx-custom.conf
@@ -17,9 +17,8 @@ server {
     }
     
     # security headers
-    add_header X-Frame-Options "SAMEORIGIN"; # don't allow iframing
+    add_header Content-Security-Policy "frame-ancestors 'self' https://plantgenie.upsc.se"; # allow iframe only from the same origin and plantgenie.upsc.se
     add_header X-Content-Type-Options "nosniff"; # prevent MIME type sniffing
-    add_header X-XSS-Protection "1; mode=block"; # Cross-site scripting (XSS) filter
 
     # cache media and font files for 30 days 
     location ~* \.(webp|svg|jpg|jpeg|png|gif|woff|woff2|ttf|eot|otf)$ {

--- a/docker/nginx-custom.conf
+++ b/docker/nginx-custom.conf
@@ -17,7 +17,7 @@ server {
     }
     
     # security headers
-    add_header Content-Security-Policy "frame-ancestors 'self' https://plantgenie.upsc.se"; # allow iframe only from the same origin and plantgenie.upsc.se
+    add_header Content-Security-Policy "frame-ancestors 'self' https://plantgenie.upsc.se http://localhost:8080"; # allow iframe only from the same origin and plantgenie.upsc.se
     add_header X-Content-Type-Options "nosniff"; # prevent MIME type sniffing
 
     # cache media and font files for 30 days 

--- a/docker/nginx-custom.conf
+++ b/docker/nginx-custom.conf
@@ -17,7 +17,7 @@ server {
     }
     
     # security headers
-    add_header Content-Security-Policy "frame-ancestors 'self' https://plantgenie.upsc.se http://localhost:8080"; # allow iframe only from the same origin and plantgenie.upsc.se
+    add_header Content-Security-Policy "frame-ancestors 'self' https://plantgenie.upsc.se"; # allow iframe only from the same origin and plantgenie.upsc.se
     add_header X-Content-Type-Options "nosniff"; # prevent MIME type sniffing
 
     # cache media and font files for 30 days 

--- a/hugo/content/embed/_index.md
+++ b/hugo/content/embed/_index.md
@@ -1,0 +1,3 @@
+---
+title: Embedded version of the Swedish Reference Genome Portal
+---

--- a/hugo/layouts/_default/embed-baseof.html
+++ b/hugo/layouts/_default/embed-baseof.html
@@ -1,0 +1,28 @@
+{{/* This is used instead of baseof.html for the embedded version of the genome browser.
+    located at: hugo/content/embed/_index.md and hugo/layouts/embed/list.html
+    Essentially a heavily stripped down version of baseof.html
+*/}}
+
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+        <title>{{ .Title }}</title>
+
+        {{/* JS needed for genome browser  */}}
+        {{ partial "add_jbrowse_js.html" . }}
+
+        {{/* Matomo tracking - Matomo recommends having it immediately before the closing </head> tag */}}
+        {{ $matomoJS := resources.Get "js/matomo.js" | fingerprint | minify }}
+        <script src="{{ $matomoJS.RelPermalink }}"></script>
+    </head>
+
+    <body class="d-flex flex-column min-vh-100">
+        <main>
+            <div class="container-fluid" id="content">
+                {{- block "main" . }}{{- end }}
+            </div>
+        </main>
+    </body>
+</html>

--- a/hugo/layouts/embed/list.html
+++ b/hugo/layouts/embed/list.html
@@ -1,0 +1,7 @@
+{{ define "script_includes" }}
+{{ partial "add_jbrowse_js.html" . }}
+{{ end }}
+
+{{ define "main" }}
+{{ partial "genome_browser.html" . }}
+{{ end }}

--- a/hugo/layouts/genome-browser/list.html
+++ b/hugo/layouts/genome-browser/list.html
@@ -1,44 +1,7 @@
 {{ define "script_includes" }}
-
-<!-- Check if the config file exists - if not display error message -->
-{{ $configCheckJS := resources.Get "js/check_for_config.js" | fingerprint | minify }}
-<script src="{{ $configCheckJS.RelPermalink }}"></script>
-
-<script defer src="/browser/static/js/main.js"></script>
-
+{{ partial "add_jbrowse_js.html" . }}
 {{ end }}
-
 
 {{ define "main" }}
-
-<div class="container-fluid mt-3">
-    <div class="row">
-        <div class="col" id="root"></div>
-    </div>
-
-    <!-- Hidden div for no config file message -->
-    <div id="no-config" style="display: none;" class="row scilife-subsection">
-        <div class="alert text-center" role="alert" style="--bs-alert-bg: #E9F2D1; --bs-alert-color: black;">
-            <h2>
-                <i class="bi bi-exclamation-triangle-fill" aria-hidden="true"></i>
-                Error: JBrowse2 Configuration File Not Found
-            </h2>
-            <p style="font-size: 1.4rem;">
-                A configuration file is needed to use the genome browser.
-                If you think this is an error, please first try to refresh the page.
-                If that doesn't work, please contact us and let us know the webpage you were trying to access.
-            </p>
-            <a href="/contact" class="btn mt-2 me-3">Contact us</a>
-            <a href="/" class="btn mt-2 ms-3">Return to Homepage</a>
-        </div>
-    </div>
-</div>
-
-{{ if hugo.IsDevelopment }}
-    <script>
-        window.__jbrowseCacheBuster = true
-    </script>
-{{ end }}
-
-
+{{ partial "genome_browser.html" . }}
 {{ end }}

--- a/hugo/layouts/partials/add_jbrowse_js.html
+++ b/hugo/layouts/partials/add_jbrowse_js.html
@@ -1,0 +1,6 @@
+{{/* JS dependencies for genome browser pages, both for regular and embedded version
+    check_for_config.js is custom script to display error if config file does not exist
+*/}}
+{{ $configCheckJS := resources.Get "js/check_for_config.js" | fingerprint | minify }}
+<script src="{{ $configCheckJS.RelPermalink }}"></script>
+<script defer src="/browser/static/js/main.js"></script>

--- a/hugo/layouts/partials/genome_browser.html
+++ b/hugo/layouts/partials/genome_browser.html
@@ -1,0 +1,28 @@
+<div class="container-fluid mt-3">
+    <div class="row">
+        <div class="col" id="root"></div>
+    </div>
+
+    {{/* Hidden div for no config file message */}}
+    <div id="no-config" style="display: none;" class="row scilife-subsection">
+        <div class="alert text-center" role="alert" style="--bs-alert-bg: #E9F2D1; --bs-alert-color: black;">
+            <h2>
+                <i class="bi bi-exclamation-triangle-fill" aria-hidden="true"></i>
+                Error: JBrowse2 Configuration File Not Found
+            </h2>
+            <p style="font-size: 1.4rem;">
+                A configuration file is needed to use the genome browser.
+                If you think this is an error, please first try to refresh the page.
+                If that doesn't work, please contact us and let us know the webpage you were trying to access.
+            </p>
+            <a href="/contact" class="btn mt-2 me-3">Contact us</a>
+            <a href="/" class="btn mt-2 ms-3">Return to Homepage</a>
+        </div>
+    </div>
+</div>
+
+{{ if hugo.IsDevelopment }}
+    <script>
+        window.__jbrowseCacheBuster = true
+    </script>
+{{ end }}


### PR DESCRIPTION
This PR covers enabling the genome browser on the portal to be iframed by plantgenie. 

To do this a new path `/embed` has been created which contains only the genome-browser and not the header/navbar etc and unnecessary JS/CSS from e.g. bootstrap. This does not impact the standard `genome-browser/ ` path that the species pages open up. I've tried to split the commits up to make the logic followed clear so hopefully that helps. 

[The current version now deployed on the dev cluster ](https://swedgene.scilifelab-2-dev.sys.kth.se/embed/?config=%2Fdata%2Fparnassius_mnemosyne%2Fconfig.json) relates to the 2nd last commit of this PR (6df6e60cdf17357d4202498fa9f6d7c4596ca3bb). 

This meant I could check the iframing works by as expected by creating an iframe of a page on the dev cluster on my browser. Which worked nicely, see pic: 
![Screenshot from 2025-04-16 15-32-51](https://github.com/user-attachments/assets/7cbc5236-d840-4e57-9ac3-1674eae378f1)

I've already reverted this (but didn't update the deployment) as the plan is not to include `localhost`, so just to make sure I don't forget to do that at the end. 