### PR TITLE
EB:520 + EB:521: Updates to the species observation map 

### DIFF
--- a/hugo/assets/css/styles.css
+++ b/hugo/assets/css/styles.css
@@ -925,6 +925,12 @@ p + .clipboard {
     background-color: var(--scilife-teal-025);
   }
 
+  .scilife-toast-body {
+    background-color: #FAF9F6;
+  }
+  .scilife-toast-header {
+    background-color: white;
+  }
 }
 
 /* Dark mode specific styles */
@@ -949,6 +955,12 @@ p + .clipboard {
     background-color: var(--scilife-teal);
   }
 
+  .scilife-toast-body {
+    background-color: #212121;
+  }
+  .scilife-toast-header {
+    background-color: #0e1111;
+  }
 
   .scilife-navbar-main li a,
   .scilife-navbar-sub li a,

--- a/hugo/assets/css/styles.css
+++ b/hugo/assets/css/styles.css
@@ -455,6 +455,42 @@ body {
   }
 }
 
+.scilife-intro-img-no-map {
+  width: auto;
+  height: 500px;
+}
+
+@media (max-width: 400px) {
+  .scilife-intro-img-no-map {
+    max-height: 300px;
+  }
+}
+
+@media (min-width: 401px) and (max-width: 576px) {
+  .scilife-intro-img-no-map {
+    max-height: 350px;
+  }
+}
+
+@media (min-width: 577px) and (max-width: 768px) {
+  .scilife-intro-img-no-map {
+    max-height: 380px;
+  }
+}
+
+@media (min-width: 769px) and (max-width: 992px) {
+  .scilife-intro-img-no-map {
+    max-height: 500px;
+  }
+}
+
+@media (min-width: 993px) {
+  .scilife-intro-img-no-map {
+    height: 550px;
+  }
+}
+
+
 .map-error-message {
   position: absolute;
   top: 50%;

--- a/hugo/assets/js/gbif_map.js
+++ b/hugo/assets/js/gbif_map.js
@@ -2,12 +2,21 @@
 Creates a population map using the GBIF API and leaflet for a given species.
 */
 
-document.addEventListener("DOMContentLoaded", function () {
+
+/**
+ * Runs on page load and initializes the global state object.
+ *
+ * @returns {Object} - The state object containing everything needed to render the species map.
+ */
+function initState() {
     const mapElement = document.getElementById('map');
     const latitude = mapElement.getAttribute('data-latitude');
     const longitude = mapElement.getAttribute('data-longitude');
     const initialZoom = mapElement.getAttribute('data-initial-zoom');
     const gbifTaxonId = mapElement.getAttribute('data-gbif-taxon-id');
+
+    // pre built html element for error message (display:none unless error)
+    const mapErrorMessage = document.getElementById('map-error-message');
 
     const map = L.map('map', {
         minZoom: 1,
@@ -16,18 +25,44 @@ document.addEventListener("DOMContentLoaded", function () {
 
     map.attributionControl.setPrefix('<a href="https://leafletjs.com" title="A JavaScript library for interactive maps">Leaflet</a>')
 
-    // Add the map tile layer from GBIF
-    // format is: https://tile.gbif.org/{srs}/{tileset}/{z}/{x}/{y}{format}{params}
-    const baseLayer = L.tileLayer('https://tile.gbif.org/3857/omt/{z}/{x}/{y}@1x.png?style=gbif-geyser-en', {
+    return {
+        map: map,
+        latitude: latitude,
+        longitude: longitude,
+        initialZoom: initialZoom,
+        gbifTaxonId: gbifTaxonId,
+        mapErrorMessage: mapErrorMessage,
+    };
+}
+
+
+/**
+ * Add the tileset layer
+ * format is: https://tile.gbif.org/{srs}/{tileset}/{z}/{x}/{y}{format}{params}
+ *
+ * @param {L.Map} map - The Leaflet map instance.
+ */
+function addBaseLayer(map) {
+    L.tileLayer('https://tile.gbif.org/3857/omt/{z}/{x}/{y}@1x.png?style=gbif-geyser-en', {
         attribution: 'Map data &copy; <a href="https://www.openstreetmap.org/">OpenStreetMap</a> contributors',
         maxZoom: 15,
     }).addTo(map);
 
-    // add the GBIF occurrence overlay
+    console.log('Base layer added');
+}
+
+
+/**
+ * Add the GBIF occurrences overlay
+ * @param {L.Map} map - The Leaflet map instance
+ * @param {string} gbifTaxonId - The GBIF taxon ID for the species.
+ * @returns {L.TileLayer} - The Leaflet tile layer for the GBIF occurrences overlay
+ */
+function addObservationLayer(map, gbifTaxonId) {
     const gbifUrl = `https://api.gbif.org/v2/map/occurrence/density/{z}/{x}/{y}@1x.png?srs=EPSG%3A3857&taxonKey=${gbifTaxonId}&style=blue.marker&year=2000,2099`;
     const gbifAttrib = '<a href="https://www.gbif.org">GBIF</a>';
 
-    const gbifLayer = L.tileLayer(gbifUrl, {
+    const obsverationLayer = L.tileLayer(gbifUrl, {
         minZoom: 1,
         maxZoom: 15,
         zoomOffset: -1,
@@ -35,51 +70,61 @@ document.addEventListener("DOMContentLoaded", function () {
         attribution: gbifAttrib
     }).addTo(map);
 
-    // event listeners for api errors
-    let mapError = false;
-    baseLayer.on('tileerror', function (error) {
-        mapError = true;
+    return obsverationLayer;
+}
+
+
+/**
+ * Add a help button, when clicked, toast pop-up happens.
+ *
+ * @param {L.Map} map - The Leaflet map instance
+ */
+function addHelpButton(map) {
+    const helpControl = L.control({ position: 'topright' });
+    const helpButtonHTML = '<button class="btn btn-light" id="helpButton" style="font-size: 1.3rem"><img src="/img/icons/question.svg" alt="Help button" class="scilife-icons-xl"></button>';
+
+    helpControl.onAdd = function (map) {
+        let div = L.DomUtil.create('div', 'help-control');
+        div.innerHTML = helpButtonHTML;
+        return div;
+    };
+
+    helpControl.addTo(map);
+
+    document.getElementById('helpButton').addEventListener('click', function () {
+        document.querySelectorAll('.toast').forEach(function (toast) {
+            toast.classList.add('show');
+        });
     });
-    gbifLayer.on('tileerror', function (error) {
-        mapError = true;
+}
+
+
+/**
+ * Setup the map on page load and add event listners to control the error message's state.
+ * The error message is set to display: none by default in the HTML.
+ */
+function main() {
+    let state = initState();
+
+    // May still be good to have this here to prevent caching issues (if error on prior page load)
+    state.map.on('load', function () {
+        state.mapErrorMessage.style.display = 'none';
     });
 
-    let hasRun = false;
-    gbifLayer.on('load', function () {
-        if (!hasRun) {
-            hasRun = true;
+    addHelpButton(state.map);
+    addBaseLayer(state.map);
 
-            if (mapError) {
-                // Update map with a generic error message.
-                if (!document.querySelector('.map-error-message')) {
-                    const errorMessage = L.control({ position: 'bottomright' });
-
-                    errorMessage.onAdd = function (map) {
-                        const div = L.DomUtil.create('div', 'map-error-message');
-                        div.innerHTML = '<h1>The distribution map is temporarily unavailable</h1>';
-                        return div;
-                    };
-                    errorMessage.addTo(map);
-                }
-            } else {
-                // Add a help button, when clicked, toast pop-up happens.
-                const helpControl = L.control({ position: 'topright' });
-                const helpButtonHTML = '<button class="btn btn-light" id="helpButton" style="font-size: 1.3rem"><img src="/img/icons/question.svg" alt="Help button" class="scilife-icons-xl"></button>';
-
-                helpControl.onAdd = function (map) {
-                    let div = L.DomUtil.create('div', 'help-control');
-                    div.innerHTML = helpButtonHTML;
-                    return div;
-                };
-
-                helpControl.addTo(map);
-
-                document.getElementById('helpButton').addEventListener('click', function () {
-                    document.querySelectorAll('.toast').forEach(function (toast) {
-                        toast.classList.add('show');
-                    });
-                });
-            }
-        }
+    // tileerror occurs if no observations are found (not caught by general error handler below)
+    const obsverationLayer = addObservationLayer(state.map, state.gbifTaxonId);
+    obsverationLayer.on('tileerror', function (event) {
+        state.mapErrorMessage.style.display = 'block';
+        console.warn('tileerror: No observations found for this taxon, check the taxon ID is correct');
     });
-});
+
+    // This includes errors triggered after initial load (e.g. user zooms in/out)
+    state.map.on('error', function () {
+        state.mapErrorMessage.style.display = 'block';
+    });
+}
+
+document.addEventListener('DOMContentLoaded', main);

--- a/hugo/assets/js/gbif_map.js
+++ b/hugo/assets/js/gbif_map.js
@@ -47,8 +47,6 @@ function addBaseLayer(map) {
         attribution: 'Map data &copy; <a href="https://www.openstreetmap.org/">OpenStreetMap</a> contributors',
         maxZoom: 15,
     }).addTo(map);
-
-    console.log('Base layer added');
 }
 
 

--- a/hugo/layouts/partials/distrib_map.html
+++ b/hugo/layouts/partials/distrib_map.html
@@ -26,12 +26,12 @@
 
 
 <!-- help pop-up for map -->
-<div class="toast position-fixed top-50 start-50 translate-middle z-3 scilife-subsection" role="alert" aria-live="assertive" aria-atomic="true">
-    <div class="toast-header">
+<div class="toast position-fixed top-50 start-50 translate-middle z-3 scilife-subsection scilife-toast" role="alert" aria-live="assertive" aria-atomic="true">
+    <div class="toast-header scilife-toast-header">
         <h4 class="me-auto">Help</h4>
         <button type="button" class="btn-close" data-bs-dismiss="toast" aria-label="Close"></button>
     </div>
-    <div class="toast-body">
+    <div class="toast-body scilife-toast-body">
         <p>
             This map shows observations of the species {{ .Params.title | markdownify }} from the year 2000 onwards.
             <br> <br>

--- a/hugo/layouts/partials/distrib_map.html
+++ b/hugo/layouts/partials/distrib_map.html
@@ -7,9 +7,15 @@
         data-longitude="{{ .Params.longitude | default 0 }}"
         data-initial-zoom="{{ .Params.initialZoom | default 1 }}"
         data-gbif-taxon-id="{{ .Params.gbif_taxon_id }}">
+
+        <!-- Message shown on error -->
+        <div id="map-error-message" class="map-error-message" style="display: none;">
+            <h1>The observation map failed to load correctly, please try again later.</h1>
+        </div>
+
     </div>
 
-    <div id="map"></div>
+
     <figcaption class="scilife-card-image-attrib">
         <a href="https://www.gbif.org/species/{{ .Params.gbif_taxon_id }}" target="_blank">
             Recorded observations of the species from the year 2000 onwards. Map generated using GBIF <i

--- a/hugo/layouts/partials/distrib_map.html
+++ b/hugo/layouts/partials/distrib_map.html
@@ -31,7 +31,7 @@
         <h4 class="me-auto">Help</h4>
         <button type="button" class="btn-close" data-bs-dismiss="toast" aria-label="Close"></button>
     </div>
-    <div class="toast-body" style="background-color: white;">
+    <div class="toast-body">
         <p>
             This map shows observations of the species {{ .Params.title | markdownify }} from the year 2000 onwards.
             <br> <br>

--- a/hugo/layouts/species/species_intro.html
+++ b/hugo/layouts/species/species_intro.html
@@ -1,20 +1,31 @@
+{{- /*
+    Note: When checking to show the observation map and its dependencies,
+    do not also check for .Params.latitude or .Params.longitude as they can be set to 0 by default which is not truthy.
+    So if user wants map but keeps them as 0, the map will not show.
+*/ -}}
+
+
 {{ define "early_connections" }}
 
-<link rel="preconnect" href="https://unpkg.com">
+{{ if .Params.initialZoom }}
+    <link rel="preconnect" href="https://unpkg.com">
+{{ end }}
 
 {{ end }}
 
 
 {{ define "script_includes" }}
 
-<link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
-integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin=""/>
+{{ if .Params.initialZoom }}
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
+    integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin=""/>
 
-<script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
-integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin="" defer></script>
+    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
+    integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin="" defer></script>
 
-{{ $gbifMap := resources.Get "js/gbif_map.js" | fingerprint | minify }}
-<script src="{{ $gbifMap.RelPermalink }}" defer></script>
+    {{ $gbifMap := resources.Get "js/gbif_map.js" | fingerprint | minify }}
+    <script src="{{ $gbifMap.RelPermalink }}" defer></script>
+{{ end }}
 
 {{ end }}
 
@@ -49,9 +60,11 @@ integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin="" d
             </figure>
         </div>
 
+        {{ if .Params.initialZoom }}
         <div class="col-lg-6 col-md-12">
             {{ partial "distrib_map.html" . }}
         </div>
+        {{ end }}
     </div>
 
 

--- a/hugo/layouts/species/species_intro.html
+++ b/hugo/layouts/species/species_intro.html
@@ -44,9 +44,19 @@
     <!-- species pic and distribution map -->
     <div class="row mt-3 d-flex">
 
-        <div class="col-lg-6 col-md-12">
+
+        {{ if .Params.initialZoom }}
+            <div class="col-lg-6 col-md-12">
+        {{ else }}
+            <div class="col-12 text-center mx-auto">
+        {{ end }}
             <figure>
-                <img src="{{ .Params.cover_image }}" class="card-img-top scilife-intro-map-img" alt="Image of {{ .Title }}">
+                {{ if .Params.initialZoom }}
+                    <img src="{{ .Params.cover_image }}" class="card-img-top scilife-intro-map-img" alt="Image of {{ .Title }}">
+                {{ else }}
+                    <img src="{{ .Params.cover_image }}" class="card-img-top scilife-intro-img-no-map" alt="Image of {{ .Title }}">
+                {{ end }}
+
                 {{ if .Params.img_attrib_link }}
                     <a href="{{ .Params.img_attrib_link }}" title="Go to the image source" target="_blank">
                         <figcaption class="scilife-card-image-attrib"> {{ .Params.img_attrib_text }} </figcaption>
@@ -56,14 +66,13 @@
                         {{ .Params.img_attrib_text }}
                     </p>
                 {{ end }}
-
             </figure>
         </div>
 
         {{ if .Params.initialZoom }}
-        <div class="col-lg-6 col-md-12">
-            {{ partial "distrib_map.html" . }}
-        </div>
+            <div class="col-lg-6 col-md-12">
+                {{ partial "distrib_map.html" . }}
+            </div>
         {{ end }}
     </div>
 


### PR DESCRIPTION
This PR covers 2 related jira tasks:

### EB-520: Investigate potential issues with the Leaflet species map (regarding showing the error message even though it displays correctly - see image from dev cluster on green toad)
![Screenshot from 2025-05-05 16-38-11](https://github.com/user-attachments/assets/75413e9c-200b-4464-92c8-8de6c47df35c)
I've made some changes and refactored the `hugo/assets/js/gbif_map.js` here which _should_ mean this is handled better. For one thing on page load this custom error message is set to display:none so refreshing the page should now clear the error, which is does not seem to do in the current version as seen on the dev cluster which is displaying the green toad branch.    

### EB-521: Make showing the species distribution map optional
I've added some if else logic to the Hugo species intro page template `hugo/layouts/species/species_intro.html ` to be able to handle a case where a species does not have a distribution map to show. In such a case a user would delete the key `.Params.initialZoom` in the species `_index.md` file to activate the alternative path of not showing the observation map. To document this change I have made a commit in the partially-automate-new-species-submissions instead of here because this is where most of that work is going on, see commit fe3e210482a0aad597466f5e13d1d2538b0378a0).

Now the page for a species without an observation map would look something like this: 
![Screenshot from 2025-05-05 16-57-50](https://github.com/user-attachments/assets/b2211f69-f405-4499-8eb8-2ffbe05121b5)
 

The design/layout for the species pages without a map could probably be improved but that can perhaps be a different Jira task. 
