### PR TITLE
EB-545: Add a show all species option to home page 

### DIFF
--- a/hugo/assets/css/styles.css
+++ b/hugo/assets/css/styles.css
@@ -425,6 +425,19 @@ body {
   border-color: #dee2e6;
 }
 
+.scilife-show-all-btn {
+  color: var(--scilife-teal);
+  background-color: #fff;
+  border-color: var(--scilife-teal);
+}
+
+.scilife-show-all-btn:hover,
+.scilife-show-all-btn:active  {
+  color: #fff;
+  background-color: var(--scilife-teal);
+}
+
+
 
 .scilife-intro-map-img {
   width: auto;

--- a/hugo/assets/js/species_cards.js
+++ b/hugo/assets/js/species_cards.js
@@ -41,6 +41,7 @@ function initState() {
         sortOrder: SORT_OPTIONS.LAST_UPDATED,
         searchText: '',
         numbMatches: 0,
+        showAllSpecies: false,
     };
     const templates = document.querySelectorAll('template[id^="card-"]');
     state.numbMatches = templates.length;
@@ -75,7 +76,7 @@ function renderSpeciesCards(state, cardContainer) {
     state.numbMatches = speciesIds.length;
 
     let speciesToDisplay;
-    if (paginationExists) {
+    if (paginationExists && !state.showAllSpecies) {
         speciesToDisplay = paginateSpecies(speciesIds, state.currentPage);
     } else {
         speciesToDisplay = speciesIds;
@@ -180,6 +181,16 @@ function updateSortDropdown(sortOrder) {
 
 
 /**
+ * If a user clicks the button to show all species, pagination buttons are hidden and all species are shown.
+ * (The show all button only exists if pagination is enabled).
+ */
+function hidePaginationButtons() {
+    paginationSection = document.querySelector('#speciesPagination');
+    paginationSection.style.display = 'none';
+}
+
+
+/**
  * Updates the page number shown as active in the pagination
  *
  * @param {number} currentPage - Page number to be shown as active.
@@ -266,6 +277,7 @@ let cardContainer;
 let paginationItems;
 let noResultsCard;
 let paginationExists;
+let showAllSpecies;
 let cardsPerPage;
 
 /**
@@ -273,8 +285,8 @@ let cardsPerPage;
  */
 function main() {
     cardContainer = document.getElementById('card-container');
-    paginationItems = document.querySelectorAll('.pagination .page-item');
     noResultsCard = document.getElementById('no-filtered-card');
+    paginationItems = document.querySelectorAll('.pagination .page-item');
     paginationExists = paginationItems.length > 0; // if not enough species, there will be no pagination yet.
     cardsPerPage = parseInt(cardContainer.dataset.numbCardsPerPage);
 
@@ -318,6 +330,17 @@ function main() {
             }
         });
     }
+
+    // Event: Show all species - this button only exists if pagination is enabled.
+    // hide pagination buttons, set state to show all species and render cards
+    if (paginationExists) {
+        document.querySelector('#showAllSpeciesBtn').addEventListener('click', (event) => {
+            state.showAllSpecies = true;
+            hidePaginationButtons();
+            renderSpeciesCards(state, cardContainer);
+        });
+    }
+
 }
 
 document.addEventListener('DOMContentLoaded', main);

--- a/hugo/layouts/index.html
+++ b/hugo/layouts/index.html
@@ -80,12 +80,14 @@
 </div>
 
 
-<!-- Add pagination if numb of species cards is > than number of species per page
-     numb species per page set in main config.yaml file -->
+<!--
+Adds pagination if numb of species cards is > than number of species per page
+numb species per page set in main config.yaml file.
+Also adds a show all button to show all species cards
+-->
 {{if gt $numbSpecies $numbSpeciesCards }}
 {{ partial "pagination.html" (dict "numbSpecies" $numbSpecies "numbSpeciesCards" $numbSpeciesCards) }}
 {{end}}
-
 
 
 

--- a/hugo/layouts/partials/pagination.html
+++ b/hugo/layouts/partials/pagination.html
@@ -4,7 +4,7 @@
 {{ $numbPages := div $numbSpecies $numbSpeciesPerPage | math.Max 2 }}
 
 
-<nav aria-label="Species cards navigation">
+<nav aria-label="Species cards navigation" id="speciesPagination">
     <ul class="pagination pagination-lg justify-content-center mt-3 scilife-pagination">
         <li class="page-item"><a class="page-link" href="#" data-page="prev">Previous</a></li>
 
@@ -17,4 +17,12 @@
 
         <li class="page-item"><a class="page-link" href="#" data-page="next">Next</a></li>
     </ul>
+
+    <!-- show all option, to swap to showing all species -->
+    <div class="text-center">
+        <button class="btn btn-lg scilife-show-all-btn" id="showAllSpeciesBtn">
+            Show all ({{ $numbSpecies }} species)
+        </button>
+    </div>
+
 </nav>


### PR DESCRIPTION
From internal discussion regarding: 
1. Having a way to click a button to "turn off pagination" and instead show all species, on a single page. 
2. Have a count of the total number of species.

![Screenshot from 2025-06-05 14-02-12](https://github.com/user-attachments/assets/b489a2f8-c5be-436d-9395-3f19192c06ec)

In current implementation clicking the button hides the pagination and shows all species. Reloading the page brings back the pagination. Let me know if you don't think this is desired behavior or think we need a way to swap back to having pagination without having to reload the page. (It would be fine to implement.)


### To test current implementation locally you can do:

- Edit the `maxSpeciesPerPage` param in `hugo/config.yaml` to a lower number to trigger pagination, e.g `2`. (Not committed as we of course don't want this). 
- Rebuild and serve image 
     ```
     docker rm -f "genome-portal"; ./scripts/dockerbuild -u -t local -k hugo ; ./scripts/dockerserve -t local
     ```

I also added 2 playwright tests to the home page for it (see 2nd commit)
```
pytest playwright/tests/test_home_page.py --base-url http://localhost:8080 --numprocesses auto
```
