### PR TITLE
EB-562: Fix Genome portal species name alignment problem

### DIFF
--- a/hugo/assets/css/styles.css
+++ b/hugo/assets/css/styles.css
@@ -357,10 +357,11 @@ body {
 }
 .scilife-species-card h2 {
   color: #222;
-  font-size: 1.25rem;
   font-weight: 700;
   letter-spacing: 0.0625rem;
   margin-top: auto;
+  font-size: 1.25rem;
+  height: calc(1.25rem * 2 + 0.5rem); /* this is to get cards of diff size texts to align */
 }
 .scilife-species-card h3 {
   color: var(--scilife-dark-grey);
@@ -383,8 +384,9 @@ body {
 
 .scilife-card-image-attrib {
   font-style: italic;
-  font-size: 0.875rem;
   color: var(--scilife-teal);
+  font-size: 0.875rem;
+  height: calc(0.875rem * 3 + 0.5rem); /* this is to get things below to align */
 }
 
 .scilife-species-button {

--- a/hugo/assets/css/styles.css
+++ b/hugo/assets/css/styles.css
@@ -359,9 +359,8 @@ body {
   color: #222;
   font-weight: 700;
   letter-spacing: 0.0625rem;
-  margin-top: auto;
+  margin-bottom: auto;
   font-size: 1.25rem;
-  height: calc(1.25rem * 2 + 0.5rem); /* this is to get cards of diff size texts to align */
 }
 .scilife-species-card h3 {
   color: var(--scilife-dark-grey);


### PR DESCRIPTION
We now have species named that are 2 lines long and the cards no longer align e.g.:
![image](https://github.com/user-attachments/assets/ba889077-f2dc-48a2-901b-0bb3e797fd9f)

As we cannot control the text exactly (e.g. how many lines each section (attribution text, species name, common name) I don't think the problem can be solved perfectly. This PR has 2 potential imperfect "solutions". I vote for the 2nd one.

**Solution 1:** 
Assumes (i.e. text will overflow if not true)
- That the text length of the image attribution will never be more than 3 lines long in the cards.
- That the species title will never be more than 2 lines long. 

**Example output:**
![first_commit](https://github.com/user-attachments/assets/819b805b-db3a-4c64-a6be-e722bcd2f257)

With this approach you see the extra space between species scientific and common name even for rows that have no need for it. 


**Solution 2:** 
Assumes (i.e. text will overflow if not true)
- That the text length of the image attribution will never be more than 3 lines long in the cards.
- (No assumptions about species name length).

![2nd_commit](https://github.com/user-attachments/assets/5d31b161-65ff-4d4d-92f4-46b27a69b641)



Bonus: Example of what would happen if we had an attribution text that was longer than 3 lines.  
![2nd_commit_stress_test](https://github.com/user-attachments/assets/10cfd41e-ea30-4ddc-b0b6-d1203a9c9a4c)

So If we take solution 2 as I suggest we should keep in mind things will go wrong if we have an image attribution in the future longer than 3 lines. Would need to modify `scilife-card-image-attrib.height` in `styles.css` accordingly. I think this is unlikely to happen though. 

@apfuentes, @brinkdp do you have any opinions? 