### PR TITLE
EB-657: Add workaround for curl download of figshare urls

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -200,7 +200,13 @@ $(CONFIG_DIR)/%/config.json:
 $(DOWNLOAD_TARGETS): $(DATA_DIR)/%:| $(DATA_DIR)/.downloads/%
 	@echo "Downloading $@ ..."; \
 	mkdir -p --mode=0755 $(@D) && \
-	curl -# -f -L --output $@ "$$(< $|)"
+	url="$$(< $|)"; \
+	case "$$url" in \
+		https://figshare.scilifelab.se/*) \
+			curl -# -f -L -A "Mozilla/5.0" --output $@ "$$url" ;; \
+		*) \
+			curl -# -f -L --output $@ "$$url" ;; \
+	esac
 
 # Recompress downloaded files using bgzip(1).
 #


### PR DESCRIPTION
During work on #107, I noticed an error that I think we might have encountered once before summer.
I hade used `./scripts/dockermake -t local clean` to purge all downloaded files in `./data` and when running the command to reinitiate them, I got this:

```
>./scripts/dockermake -t local

Downloading data/blastobotrys_illinoisensis/billinoisensis_annotation.gff.nozip ...
curl: (22) The requested URL returned error: 403                           
```

I do not know if SLL Data Repository has been updated recently, or if it was just a specific figshare item that suffered from this? Anyway, I did some investigations and have come up with a suggestion for a fix.

The make recipe that handles the download of remote files uses `curl -# -f -L`; `-#` is to show the progress bar, `-f` is to fail with error code 22, `-L` is to follow through with a request to a new location if the link redirects. Figshare files for instance need `-L` since the download link redirects to time-limited S3 urls. But overall there seems to be nothing fancy going on with these flags.

Interestingly, the url that causes curl to fail works when called in the browser, but not when called from the command line with curl.  So I googled for "curl url download works from browser but not command line" and found a [stack exchange thread](https://unix.stackexchange.com/questions/321710/why-wont-curl-download-this-link-when-a-browser-will) and learned that some servers required headers in the GET requests. One useful suggestion was to use the Chrome dev console to get the curl url sent by the browser when clicking the download link on the Figshare page. Indeed, it sent several headers. Another suggestion from the thread was to use that info to try to find the minimal required headers, and to start with `User-agent`. User agents can be supplied with `curl -A`, so I tried to add one found by the dev console and I was able to download the file from the command line with `curl -# -f -L -A "Mozilla/5.0" <URL>`.

In the first commit of this PR, I modified the download recipe to check if the url begins with `https://figshare.scilifelab.se/*` and, if so, run `curl -# -f -L -A "Mozilla/5.0" <URL>`; if not, run regular `curl -# -f -L <URL>`.  This alleviates the errors and I was able to successfully run `./scripts/dockermake -t local` to reinitiate the purged `./data` dir.

This seem to work, but perhaps there is an simpler fix to this? Happy for any input on this!