### PR TITLE
SQ-850: Fix GWAS plugin not rendering

### DIFF
--- a/config/anthophora_plagiata/config.json
+++ b/config/anthophora_plagiata/config.json
@@ -117,7 +117,7 @@
   "plugins": [
     {
       "name": "GWAS",
-      "url": "https://unpkg.com/jbrowse-plugin-gwas/dist/jbrowse-plugin-gwas.umd.production.min.js"
+      "url": "/browser/plugins/jbrowse-plugin-gwas.umd.production.min.js"
     }
   ],
   "tracks": [

--- a/config/anthophora_quadrimaculata/config.json
+++ b/config/anthophora_quadrimaculata/config.json
@@ -117,7 +117,7 @@
   "plugins": [
     {
       "name": "GWAS",
-      "url": "https://unpkg.com/jbrowse-plugin-gwas/dist/jbrowse-plugin-gwas.umd.production.min.js"
+      "url": "/browser/plugins/jbrowse-plugin-gwas.umd.production.min.js"
     }
   ],
   "tracks": [

--- a/config/anthophora_retusa/config.json
+++ b/config/anthophora_retusa/config.json
@@ -117,7 +117,7 @@
   "plugins": [
     {
       "name": "GWAS",
-      "url": "https://unpkg.com/jbrowse-plugin-gwas/dist/jbrowse-plugin-gwas.umd.production.min.js"
+      "url": "/browser/plugins/jbrowse-plugin-gwas.umd.production.min.js"
     }
   ],
   "tracks": [

--- a/config/linum_tenue/config.json
+++ b/config/linum_tenue/config.json
@@ -309,7 +309,7 @@
     "plugins": [
       {
         "name": "GWAS",
-        "url": "https://unpkg.com/jbrowse-plugin-gwas/dist/jbrowse-plugin-gwas.umd.production.min.js"
+        "url": "/browser/plugins/jbrowse-plugin-gwas.umd.production.min.js"
       },
       {
         "name": "DbxrefPlugin",

--- a/config/linum_trigynum/config.json
+++ b/config/linum_trigynum/config.json
@@ -303,7 +303,7 @@
   "plugins": [
     {
       "name": "GWAS",
-      "url": "https://unpkg.com/jbrowse-plugin-gwas/dist/jbrowse-plugin-gwas.umd.production.min.js"
+      "url": "/browser/plugins/jbrowse-plugin-gwas.umd.production.min.js"
     }
   ],
   "tracks": [

--- a/docker/hugo.dockerfile
+++ b/docker/hugo.dockerfile
@@ -42,7 +42,7 @@ ARG JBROWSE_VERSION
 ARG GWAS_PLUGIN_VERSION
 
 WORKDIR /tmp
-RUN npm install -g @jbrowse/cli
+RUN npm install -g @jbrowse/cli@${JBROWSE_VERSION}
 COPY ./scripts/download_jbrowse .
 RUN bash ./download_jbrowse v${JBROWSE_VERSION} /tmp/browser
 

--- a/docker/hugo.dockerfile
+++ b/docker/hugo.dockerfile
@@ -1,13 +1,15 @@
 ARG NODE_VERSION=22.2.0
 ARG JBROWSE_VERSION=4.1.13
 
-# Stage 1: Download HUGO + build static site. 
-FROM alpine:latest AS build
+## Stage 1: Download HUGO + build static site. 
+
+# Use debian instead of alpine for build to avoid a MacOS + Rancher desktop build issue.
+FROM debian:stable-slim AS build
 
 ARG HUGO_VERSION=0.138.0
 ARG JBROWSE_VERSION
 
-RUN apk add --no-cache wget
+RUN apt-get update && apt-get install -y --no-install-recommends wget ca-certificates && rm -rf /var/lib/apt/lists/*
 
 RUN wget --quiet "https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_${HUGO_VERSION}_Linux-64bit.tar.gz" && \
     tar xzf hugo_${HUGO_VERSION}_Linux-64bit.tar.gz && \
@@ -26,11 +28,14 @@ ARG HUGO_GIT_REF_NAME
 ARG HUGO_GIT_SHA
 
 # pass the environment variables to the build
+# On MacOS with Rancher desktop, the build VM can run out of memory when building the hugo image, causing a crash in Go's lfstack implementation. 
+# Setting GOGC=off disables Go's runtime GC, working around this issue.
+
 RUN mkdir /target && \
-    hugo -d /target --minify --gc
+    GOGC=off hugo -d /target --minify --gc
 
 
-# Stage 2: Install JBrowse
+## Stage 2: Install JBrowse and GWAS plugin
 FROM node:${NODE_VERSION}-slim AS jbrowse
 ARG JBROWSE_VERSION
 
@@ -39,8 +44,7 @@ RUN npm install -g @jbrowse/cli
 COPY ./scripts/download_jbrowse .
 RUN bash ./download_jbrowse v${JBROWSE_VERSION} /tmp/browser
 
-
-# Stage 3: Serve the generated html using nginx
+## Stage 3: Serve the generated html using nginx
 FROM nginxinc/nginx-unprivileged:stable-alpine
 
 COPY docker/nginx-custom.conf /etc/nginx/conf.d/default.conf 

--- a/docker/hugo.dockerfile
+++ b/docker/hugo.dockerfile
@@ -1,5 +1,6 @@
 ARG NODE_VERSION=22.2.0
 ARG JBROWSE_VERSION=4.1.13
+ARG GWAS_PLUGIN_VERSION=2.1.4
 
 ## Stage 1: Download HUGO + build static site. 
 
@@ -38,11 +39,19 @@ RUN mkdir /target && \
 ## Stage 2: Install JBrowse and GWAS plugin
 FROM node:${NODE_VERSION}-slim AS jbrowse
 ARG JBROWSE_VERSION
+ARG GWAS_PLUGIN_VERSION
 
 WORKDIR /tmp
 RUN npm install -g @jbrowse/cli
 COPY ./scripts/download_jbrowse .
 RUN bash ./download_jbrowse v${JBROWSE_VERSION} /tmp/browser
+
+# Download pinned version of jbrowse-plugin-gwas and bundle it with the image
+RUN mkdir -p /tmp/browser/plugins /tmp/gwas-plugin-stage && \
+    npm pack "jbrowse-plugin-gwas@${GWAS_PLUGIN_VERSION}" --pack-destination /tmp && \
+    tar -xzf "/tmp/jbrowse-plugin-gwas-${GWAS_PLUGIN_VERSION}.tgz" -C /tmp/gwas-plugin-stage --strip-components=1 && \
+    cp /tmp/gwas-plugin-stage/dist/jbrowse-plugin-gwas.umd.production.min.js /tmp/browser/plugins/
+
 
 ## Stage 3: Serve the generated html using nginx
 FROM nginxinc/nginx-unprivileged:stable-alpine

--- a/docker/hugo.dockerfile
+++ b/docker/hugo.dockerfile
@@ -1,5 +1,5 @@
 ARG NODE_VERSION=22.2.0
-ARG JBROWSE_VERSION=3.2.0
+ARG JBROWSE_VERSION=4.1.13
 
 # Stage 1: Download HUGO + build static site. 
 FROM alpine:latest AS build

--- a/scripts/configure_defaultSession/default_session_builder.py
+++ b/scripts/configure_defaultSession/default_session_builder.py
@@ -69,7 +69,7 @@ class TrackParams:
         if track_params.display_type == "LinearManhattanDisplay":
             return {
                 "name": "GWAS",
-                "url": "https://unpkg.com/jbrowse-plugin-gwas/dist/jbrowse-plugin-gwas.umd.production.min.js",
+                "url": "/browser/plugins/jbrowse-plugin-gwas.umd.production.min.js",
             }
         return None
 

--- a/scripts/configure_defaultSession/tests/fixtures/config.json
+++ b/scripts/configure_defaultSession/tests/fixtures/config.json
@@ -270,7 +270,7 @@
   "plugins": [
     {
       "name": "GWAS",
-      "url": "https://unpkg.com/jbrowse-plugin-gwas/dist/jbrowse-plugin-gwas.umd.production.min.js"
+      "url": "/browser/plugins/jbrowse-plugin-gwas.umd.production.min.js"
     }
   ]
 }

--- a/tests/config/defaultSession_helper/config.json
+++ b/tests/config/defaultSession_helper/config.json
@@ -121,7 +121,7 @@
   "plugins": [
     {
       "name": "GWAS",
-      "url": "https://unpkg.com/jbrowse-plugin-gwas/dist/jbrowse-plugin-gwas.umd.production.min.js"
+      "url": "/browser/plugins/jbrowse-plugin-gwas.umd.production.min.js"
     }
   ],
   "tracks": [

--- a/tests/config/gwas_testing_ground/config.json
+++ b/tests/config/gwas_testing_ground/config.json
@@ -2,7 +2,7 @@
   "plugins": [
     {
       "name": "GWAS",
-      "url": "https://unpkg.com/jbrowse-plugin-gwas/dist/jbrowse-plugin-gwas.umd.production.min.js"
+      "url": "/browser/plugins/jbrowse-plugin-gwas.umd.production.min.js"
     }
   ],
   "tracks": [

--- a/tests/config/linum_popgen/config.json
+++ b/tests/config/linum_popgen/config.json
@@ -85,7 +85,7 @@
     "plugins": [
       {
         "name": "GWAS",
-        "url": "https://unpkg.com/jbrowse-plugin-gwas/dist/jbrowse-plugin-gwas.umd.production.min.js"
+        "url": "/browser/plugins/jbrowse-plugin-gwas.umd.production.min.js"
       }
     ],
     "tracks": [


### PR DESCRIPTION
Hi @RMCrean 

This PR is for fixing the recent error in the GWAS plugin tracks. As I suspected, the error was fixed by bumping JBrowse to the latest version (from 3.2.0 to 4.1.13). I put the JBrowse-bump (fdf5603457eada262fdcf53eb9259d65d9f52c14) on the dev cluster, and also on prod as a hotfix while we wait for this PR to be merged.

I also decided to try to pin the GWAS plugin version so that we can avoid runaway dependency bugs like this. Previously, the plugin was loaded from npm on runtime whenever a user accessed a JBrowse track that used the plugin. Now I changed it so that a pinned version is downloaded during build time, and pointed the config.json files to that path in the docker image instead of the external npm URL. Do you agree that this is a good way to handle this?

Now for a head-scratcher.  Remember that I have had problems building the hugo docker image locally on MacOS since I switched to Rancher Desktop? In order to conveniently test the build time strategy for the plugin, I needed to be able to build local images. Here I admit I had to resort to asking Claude AI for help. Apparently, the combination of alpine for the build image and the GO Garbage Collection settings resulted in a GO memory address handling bug. After iterating on the error with AI, I found that using a debian image (glibc-based) instead of alpine (musl libc-based) for the build step AND turning off GO Garbage Collection fixed the bug. The final stage is still using the nginx image. I deployed to dev from ce90f90 and it seems to work fine. Can you check if you can run `./scripts/dockerbuild -u -t local -k hugo` on this branch on your laptop without problem?

When we are happy with this, I can make a new release. I will also then rebuild the `config.json` files on the clusters so that they point to the GWAS plugin files in the image (at the moment the files on the clusters still point to the remote CDN).