### PR TITLE
CI: Pally update config and modify renovate settings

### DIFF
--- a/.github/pa11y.config
+++ b/.github/pa11y.config
@@ -3,6 +3,8 @@
         "standard": "WCAG2AA",
         "level": "error",
         "chromeLaunchConfig": {
+            "args": ["--disable-dev-shm-usage", "--no-sandbox"],
+            "executablePath": "/usr/bin/google-chrome",
             "ignoreHTTPSErrors": true,
             "args": ["--disable-dev-shm-usage", "--no-sandbox"]
         },

--- a/.github/workflows/pa11y-ci.yml
+++ b/.github/workflows/pa11y-ci.yml
@@ -16,10 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-      - name: Set up Node.js 22.x
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+      - name: Set up Node.js 24.x
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 24.x
 

--- a/.github/workflows/pa11y-ci.yml
+++ b/.github/workflows/pa11y-ci.yml
@@ -7,6 +7,7 @@ on:
       - "hugo/**"
       - "docker/hugo.dockerfile"
       - ".github/workflows/pa11y-ci.yml"
+      - ".github/pa11y.config"
 
 jobs:
   Pa11y:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
       with:
-        python-version: '3.11'
+        python-version: '3.11' # Some requirements.txt packages will need to be bumped if we want to bump this. 
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 20
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
     - name: Set up Python
       uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6

--- a/.github/workflows/precommit.yml
+++ b/.github/workflows/precommit.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
     - name: Set up Python
       uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6

--- a/.github/workflows/publish_images.yml
+++ b/.github/workflows/publish_images.yml
@@ -43,10 +43,10 @@ jobs:
         
     steps:
       - name: Check out the repo
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master
@@ -30,7 +30,7 @@ jobs:
           severity: "CRITICAL,HIGH"
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@0d579ffd059c29b07949a3cce3983f0780820c98 # v4
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
         with:
           sarif_file: "trivy-results.sarif"
           category: trivy

--- a/renovate.json
+++ b/renovate.json
@@ -4,12 +4,18 @@
   "schedule": "* 9-12 * * 1",
   "packageRules": [
     {
-      "matchFileNames": ["requirements.txt"],
+      "matchFileNames": ["requirements.txt", "add_species.dockerfile"],
       "enabled": false
     },
     {
       "matchManagers": ["github-actions"],
-      "matchPackageNames": ["python"],
+      "matchDepNames": ["python"],
+      "enabled": false
+    },
+    {
+      "matchFileNames": [".github/workflows/playwright.yml"],
+      "matchManagers": ["github-actions"],
+      "matchDepNames": ["python"],
       "enabled": false
     },
     {


### PR DESCRIPTION
Creating this branch primarly so I can see if the pa11y GH action now passes with these edits. 

Change of renovate settings to stop the repeated attempts to bump the python version used because:
- this is a dev only dependency (no security risks etc...). 
- We have pkgs dependent on lower versions of python, which would be notable work to upgrade. 