### PR TITLE
Adjust code owners to be team freya

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,1 @@
-# The data science node in evolution and biodiversity are the owners of all files in this repository
-* @ScilifelabDataCentre/dsn-eb
+* @ScilifelabDataCentre/teamfreya


### PR DESCRIPTION
This enables pull requests to go to the whole team, It will move it away from being DSN-EB (the team on GitHub can later be dissolved, as everyone is now in TeamFreya. 